### PR TITLE
feat: Support Wormhole and EVM Proof for binding tokens

### DIFF
--- a/src/chains/near.ts
+++ b/src/chains/near.ts
@@ -6,6 +6,8 @@ import {
   ChainKind,
   type DeployTokenArgs,
   DeployTokenArgsSchema,
+  type EvmVerifyProofArgs,
+  EvmVerifyProofArgsSchema,
   type LogMetadataArgs,
   type OmniAddress,
   ProofKind,
@@ -102,16 +104,51 @@ export class NearDeployer implements ChainDeployer<Account> {
     return tx.transaction.hash
   }
 
-  async bindToken(destinationChain: ChainKind, vaa: string): Promise<string> {
-    const proverArgs: WormholeVerifyProofArgs = {
-      proof_kind: ProofKind.DeployToken,
-      vaa: vaa,
+  /**
+   * Binds a token on the NEAR chain using either a VAA (Wormhole) or EVM proof
+   * @param sourceChain - Source chain for binding
+   * @param vaa - Verified Action Approval for Wormhole verification
+   * @param evmProof - EVM proof for Ethereum or EVM chain verification
+   * @throws {Error} If VAA or EVM proof is not provided
+   * @returns Transaction hash of the bind token transaction
+   */
+  async bindToken(
+    sourceChain: ChainKind,
+    vaa?: string,
+    evmProof?: EvmVerifyProofArgs,
+  ): Promise<string> {
+    if (!vaa && !evmProof) {
+      throw new Error("Must provide either VAA or EVM proof")
     }
-    const proverArgsSerialized = borshSerialize(WormholeVerifyProofArgsSchema, proverArgs)
+
+    if (evmProof) {
+      if (
+        sourceChain !== ChainKind.Eth &&
+        sourceChain !== ChainKind.Arb &&
+        sourceChain !== ChainKind.Base
+      ) {
+        throw new Error("EVM proof is only valid for Ethereum, Arbitrum, or Base")
+      }
+    }
+
+    let proverArgsSerialized: Buffer = Buffer.alloc(0)
+    if (vaa) {
+      const proverArgs: WormholeVerifyProofArgs = {
+        proof_kind: ProofKind.DeployToken,
+        vaa: vaa,
+      }
+      proverArgsSerialized = borshSerialize(WormholeVerifyProofArgsSchema, proverArgs)
+    } else if (evmProof) {
+      const proverArgs: EvmVerifyProofArgs = {
+        proof_kind: ProofKind.DeployToken,
+        proof: evmProof.proof,
+      }
+      proverArgsSerialized = borshSerialize(EvmVerifyProofArgsSchema, proverArgs)
+    }
 
     // Construct bind token arguments
     const args: BindTokenArgs = {
-      chain_kind: destinationChain,
+      chain_kind: sourceChain,
       prover_args: proverArgsSerialized,
     }
     const tx = await this.wallet.functionCall({

--- a/src/types/omni.ts
+++ b/src/types/omni.ts
@@ -1,6 +1,6 @@
 import type { ChainKind } from "./chain"
 import type { OmniAddress } from "./common"
-import type { ProofKind } from "./prover"
+import type { EvmVerifyProofArgs, ProofKind } from "./prover"
 
 export type TokenDeployment = {
   id: string
@@ -42,12 +42,13 @@ export interface ChainDeployer<_TWallet> {
   finDeployToken(destinationChain: ChainKind, vaa: string): Promise<string>
 
   /**
-   * Binds a token using a VAA
-   * @param destinationChain - Target chain for binding
+   * Binds a token using either a VAA (Wormhole) or EVM proof
+   * @param sourceChain - Source chain for binding
    * @param vaa - The Verified Action Approval
+   * @param evmProof - The EVM proof
    * @returns Transaction hash of the binding
    */
-  bindToken(destinationChain: ChainKind, vaa: string): Promise<string>
+  bindToken(sourceChain: ChainKind, vaa?: string, evmProof?: EvmVerifyProofArgs): Promise<string>
 }
 
 export interface TransferMessage {


### PR DESCRIPTION
This only supports the EVM Proof schema. We still need to automatically ascertain this information via the RPC, likely via a separate helper method or util, such as `getEthProof`