### PR TITLE
Rename deployer to bridge client

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ yarn add omni-bridge-sdk
 The SDK currently provides a split interface for cross-chain transfers:
 
 - `omniTransfer`: A unified interface for initiating transfers from any supported chain
-- Chain-specific deployers: Required for finalizing transfers on destination chains
+- Chain-specific clients: Required for finalizing transfers on destination chains
 
 > [!NOTE]  
-> We're working on unifying this into a single interface that will handle the complete transfer lifecycle. For now, you'll need to use both `omniTransfer` and chain-specific deployers as shown below.
+> We're working on unifying this into a single interface that will handle the complete transfer lifecycle. For now, you'll need to use both `omniTransfer` and chain-specific clients as shown below.
 
 Here's a complete example:
 
@@ -53,7 +53,7 @@ import {
   ChainKind,
   omniAddress,
   OmniBridgeAPI,
-  getDeployer,
+  getClient,
 } from "omni-bridge-sdk";
 import { connect } from "near-api-js";
 
@@ -97,8 +97,8 @@ do {
 
   if (status === "ready_for_finalize") {
     // 4. Finalize transfer on destination chain
-    const ethDeployer = getDeployer(ChainKind.Eth, ethWallet);
-    await ethDeployer.finalizeTransfer(transferMessage, signature);
+    const ethClient = getClient(ChainKind.Eth, ethWallet);
+    await ethClient.finalizeTransfer(transferMessage, signature);
     break;
   }
 
@@ -131,16 +131,16 @@ const status = await api.getTransferStatus(chain, nonce);
 
 ### 3. Transfer Finalization
 
-When status is "ready_for_finalize", use chain-specific deployers to complete the transfer:
+When status is "ready_for_finalize", use chain-specific clients to complete the transfer:
 
 ```typescript
 // Finalize on Ethereum/EVM chains
-const evmDeployer = getDeployer(ChainKind.Eth, ethWallet);
-await evmDeployer.finalizeTransfer(transferMessage, signature);
+const evmClient = getClient(ChainKind.Eth, ethWallet);
+await evmClient.finalizeTransfer(transferMessage, signature);
 
 // Finalize on NEAR
-const nearDeployer = getDeployer(ChainKind.Near, nearAccount);
-await nearDeployer.finalizeTransfer(
+const nearClient = getClient(ChainKind.Near, nearAccount);
+await nearClient.finalizeTransfer(
   token,
   recipientAccount,
   storageDeposit,
@@ -149,8 +149,8 @@ await nearDeployer.finalizeTransfer(
 );
 
 // Finalize on Solana
-const solDeployer = getDeployer(ChainKind.Sol, provider);
-await solDeployer.finalizeTransfer(transferMessage, signature);
+const solClient = getClient(ChainKind.Sol, provider);
+await solClient.finalizeTransfer(transferMessage, signature);
 ```
 
 ## Core Concepts
@@ -245,20 +245,20 @@ const result = await omniTransfer(provider, transfer);
 
 ### Deploying Tokens
 
-Token deployment uses chain-specific deployers through a unified interface:
+Token deployment uses chain-specific clients through a unified interface:
 
 ```typescript
-import { getDeployer } from "omni-bridge-sdk";
+import { getClient } from "omni-bridge-sdk";
 
-// Initialize deployer for source chain
-const deployer = getDeployer(ChainKind.Near, wallet);
+// Initialize client for source chain
+const client = getClient(ChainKind.Near, wallet);
 
 // Example: Deploy NEAR token to Ethereum
-const txHash = await deployer.logMetadata("near:token.near");
+const txHash = await client.logMetadata("near:token.near");
 console.log(`Metadata logged with tx: ${txHash}`);
 
 // Deploy token with signed MPC payload
-const result = await deployer.deployToken(signature, {
+const result = await client.deployToken(signature, {
   token: "token.near",
   name: "Token Name",
   symbol: "TKN",

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,9 +2,9 @@ import { AnchorProvider as SolWallet } from "@coral-xyz/anchor"
 import { PublicKey } from "@solana/web3.js"
 import { Wallet as EthWallet } from "ethers"
 import { Account as NearAccount } from "near-api-js"
-import { EVMDeployer } from "./deployer/evm"
-import { NearDeployer } from "./deployer/near"
-import { SolanaDeployer } from "./deployer/solana"
+import { EvmBridgeClient } from "./clients/evm"
+import { NearBridgeClient } from "./clients/near"
+import { SolanaBridgeClient } from "./clients/solana"
 import { ChainKind, type OmniTransferMessage, type OmniTransferResult } from "./types"
 
 export async function omniTransfer(
@@ -12,8 +12,8 @@ export async function omniTransfer(
   transfer: OmniTransferMessage,
 ): Promise<OmniTransferResult> {
   if (wallet instanceof NearAccount) {
-    const deployer = new NearDeployer(wallet, "omni-locker.testnet") // TODO: Get from config
-    const { nonce, hash } = await deployer.initTransfer(
+    const client = new NearBridgeClient(wallet)
+    const { nonce, hash } = await client.initTransfer(
       transfer.tokenAddress,
       transfer.recipient,
       transfer.amount,
@@ -25,8 +25,8 @@ export async function omniTransfer(
   }
 
   if (wallet instanceof EthWallet) {
-    const deployer = new EVMDeployer(wallet, ChainKind.Eth)
-    const { hash, nonce } = await deployer.initTransfer(
+    const client = new EvmBridgeClient(wallet, ChainKind.Eth)
+    const { hash, nonce } = await client.initTransfer(
       transfer.tokenAddress,
       transfer.recipient,
       transfer.amount,
@@ -38,11 +38,11 @@ export async function omniTransfer(
   }
 
   if (wallet instanceof SolWallet) {
-    const deployer = new SolanaDeployer(
+    const client = new SolanaBridgeClient(
       wallet,
       new PublicKey("3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5"),
     ) // TODO: Get from config
-    const { nonce, hash } = await deployer.initTransfer(
+    const { nonce, hash } = await client.initTransfer(
       transfer.tokenAddress,
       transfer.recipient,
       transfer.amount,

--- a/src/clients/evm.ts
+++ b/src/clients/evm.ts
@@ -68,15 +68,15 @@ const FACTORY_ADDRESSES: Record<ChainTag<EVMChainKind>, string | undefined> = {
 }
 
 /**
- * EVM blockchain implementation of the token deployer
+ * EVM blockchain implementation of the bridge client
  */
-export class EVMDeployer {
+export class EvmBridgeClient {
   private factory: ethers.Contract
   private chainKind: EVMChainKind
   private chainTag: ChainTag<EVMChainKind>
 
   /**
-   * Creates a new EVM token deployer instance
+   * Creates a new EVM bridge client instance
    * @param wallet - Ethereum signer instance for transaction signing
    * @param chain - The EVM chain to deploy to (Ethereum, Base, or Arbitrum)
    * @throws {Error} If factory address is not configured for the chain or if chain is not EVM
@@ -109,7 +109,7 @@ export class EVMDeployer {
   async logMetadata(tokenAddress: OmniAddress): Promise<string> {
     const sourceChain = getChain(tokenAddress)
 
-    // Validate source chain matches the deployer's chain
+    // Validate source chain matches the client's chain
     if (!ChainUtils.areEqual(sourceChain, this.chainKind)) {
       throw new Error(`Token address must be on ${this.chainTag}`)
     }
@@ -175,7 +175,7 @@ export class EVMDeployer {
   ): Promise<{ hash: string; nonce: number }> {
     const sourceChain = getChain(token)
 
-    // Validate source chain matches the deployer's chain
+    // Validate source chain matches the client's chain
     if (!ChainUtils.areEqual(sourceChain, this.chainKind)) {
       throw new Error(`Token address must be on ${this.chainTag}`)
     }

--- a/src/clients/near.ts
+++ b/src/clients/near.ts
@@ -85,22 +85,22 @@ interface BalanceResults {
 }
 
 /**
- * NEAR blockchain implementation of the token deployer.
+ * NEAR blockchain implementation of the bridge client.
  * Handles token deployment, binding, and transfer operations on the NEAR blockchain.
  */
-export class NearDeployer {
+export class NearBridgeClient {
   /**
-   * Creates a new NEAR token deployer instance
+   * Creates a new NEAR bridge client instance
    * @param wallet - NEAR account instance for transaction signing
    * @param lockerAddress - Address of the token locker contract
    * @throws {Error} If locker address is not configured
    */
   constructor(
     private wallet: Account,
-    private lockerAddress: string = process.env.OMNI_LOCKER_NEAR as string,
+    private lockerAddress: string = process.env.OMNI_BRIDGE_NEAR as string,
   ) {
     if (!this.lockerAddress) {
-      throw new Error("OMNI_LOCKER_NEAR address not configured")
+      throw new Error("OMNI_BRIDGE_NEAR address not configured")
     }
   }
 

--- a/src/clients/solana.ts
+++ b/src/clients/solana.ts
@@ -23,7 +23,7 @@ import { getChain } from "../utils"
 
 const MPL_PROGRAM_ID = new PublicKey("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s")
 
-export class SolanaDeployer {
+export class SolanaBridgeClient {
   private readonly wormholeProgramId: PublicKey
   private readonly program: Program<BridgeTokenFactory>
 
@@ -45,18 +45,24 @@ export class SolanaDeployer {
     SOL_VAULT: this.getConstant("SOL_VAULT_SEED"),
   }
 
-  constructor(provider: Provider, wormholeProgramId: PublicKey) {
+  constructor(
+    provider: Provider,
+    wormholeProgramId: PublicKey = new PublicKey(process.env.WORMHOLE_SOL as string),
+  ) {
     this.wormholeProgramId = wormholeProgramId
     this.program = new Program(BRIDGE_TOKEN_FACTORY_IDL as BridgeTokenFactory, provider)
   }
 
   private config(): [PublicKey, number] {
-    return PublicKey.findProgramAddressSync([SolanaDeployer.SEEDS.CONFIG], this.program.programId)
+    return PublicKey.findProgramAddressSync(
+      [SolanaBridgeClient.SEEDS.CONFIG],
+      this.program.programId,
+    )
   }
 
   private authority(): [PublicKey, number] {
     return PublicKey.findProgramAddressSync(
-      [SolanaDeployer.SEEDS.AUTHORITY],
+      [SolanaBridgeClient.SEEDS.AUTHORITY],
       this.program.programId,
     )
   }
@@ -84,21 +90,21 @@ export class SolanaDeployer {
 
   private wrappedMintId(token: string): [PublicKey, number] {
     return PublicKey.findProgramAddressSync(
-      [SolanaDeployer.SEEDS.WRAPPED_MINT, Buffer.from(token, "utf-8")],
+      [SolanaBridgeClient.SEEDS.WRAPPED_MINT, Buffer.from(token, "utf-8")],
       this.program.programId,
     )
   }
 
   private vaultId(mint: PublicKey): [PublicKey, number] {
     return PublicKey.findProgramAddressSync(
-      [SolanaDeployer.SEEDS.VAULT, mint.toBuffer()],
+      [SolanaBridgeClient.SEEDS.VAULT, mint.toBuffer()],
       this.program.programId,
     )
   }
 
   private solVaultId(): [PublicKey, number] {
     return PublicKey.findProgramAddressSync(
-      [SolanaDeployer.SEEDS.SOL_VAULT],
+      [SolanaBridgeClient.SEEDS.SOL_VAULT],
       this.program.programId,
     )
   }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,32 +1,36 @@
+import type { AnchorProvider } from "@coral-xyz/anchor"
 import type { ethers } from "ethers"
 import type { Account } from "near-api-js"
-import { EVMDeployer } from "./deployer/evm"
-import { NearDeployer } from "./deployer/near"
+import { EvmBridgeClient } from "./clients/evm"
+import { NearBridgeClient } from "./clients/near"
+import { SolanaBridgeClient } from "./clients/solana"
 import { ChainKind } from "./types"
 
 /**
- * Creates a chain-specific deployer instance
- * @param chain - The blockchain network to create a deployer for
+ * Creates a chain-specific bridge client instance
+ * @param chain - The blockchain network to create a client for
  * @param wallet - Chain-specific wallet instance for signing transactions
- * @returns A deployer instance for the specified chain
- * @throws {Error} If no deployer implementation exists for the chain
+ * @returns A client instance for the specified chain
+ * @throws {Error} If no client implementation exists for the chain
  *
  * @example
  * ```typescript
  * const nearAccount = await connect(config);
- * const deployer = getDeployer(ChainKind.Near, nearAccount);
- * const txHash = await deployer.initDeployToken("near:token.near");
+ * const client = getClient(ChainKind.Near, nearAccount);
+ * const txHash = await client.initDeployToken("near:token.near");
  * ```
  */
-export function getDeployer<TWallet>(chain: ChainKind, wallet: TWallet) {
+export function getClient<TWallet>(chain: ChainKind, wallet: TWallet) {
   switch (chain) {
     case ChainKind.Near:
-      return new NearDeployer(wallet as Account)
+      return new NearBridgeClient(wallet as Account)
     case ChainKind.Eth:
     case ChainKind.Base:
     case ChainKind.Arb:
-      return new EVMDeployer(wallet as ethers.Signer, chain)
+      return new EvmBridgeClient(wallet as ethers.Signer, chain)
+    case ChainKind.Sol:
+      return new SolanaBridgeClient(wallet as AnchorProvider)
     default:
-      throw new Error(`No deployer implementation for chain: ${chain}`)
+      throw new Error(`No client implementation for chain: ${chain}`)
   }
 }


### PR DESCRIPTION
Feels better fitting since it doesn't just deploy tokens now