### PR TITLE
Add support for NEAR Wallet Selector

### DIFF
--- a/.changeset/unlucky-lobsters-shave.md
+++ b/.changeset/unlucky-lobsters-shave.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": minor
+---
+
+Add support for NEAR Wallet Selector as an alternative to near-api-js for NEAR chain interactions.

--- a/README.md
+++ b/README.md
@@ -57,16 +57,25 @@ When transferring from NEAR to another chain (e.g., Ethereum, Solana), you need 
 2. Sign the transfer message
 3. Use the signature for finalization on the destination chain
 
+You can use either [near-api-js](https://github.com/near/near-api-js) or [NEAR Wallet Selector](https://github.com/near/wallet-selector) for NEAR interactions:
+
 ```typescript
-// Setup NEAR account and destination wallet
+// Using near-api-js
 const near = await connect({
   networkId: "testnet",
   nodeUrl: "https://rpc.testnet.near.org",
 });
 const account = await near.account("sender.near");
-const ethWallet = new ethers.providers.Web3Provider(
-  window.ethereum
-).getSigner();
+const nearClient = getClient(ChainKind.Near, account);
+
+// OR using NEAR Wallet Selector
+const selector = await setupWalletSelector({
+  network: "testnet",
+  modules: [
+    /* your wallet modules */
+  ],
+});
+const nearClient = getClient(ChainKind.Near, selector);
 
 // Create and initiate transfer
 const transfer = {
@@ -81,7 +90,6 @@ const transfer = {
 const result = await omniTransfer(account, transfer);
 
 // Sign transfer on NEAR
-const nearClient = getClient(ChainKind.Near, account);
 const { signature } = await nearClient.signTransfer(result, "sender.near");
 
 // Finalize on destination (e.g., Ethereum)
@@ -292,7 +300,7 @@ try {
 Currently supported chains:
 
 - Ethereum (ETH)
-- NEAR
+- NEAR (with support for both near-api-js and Wallet Selector)
 - Solana (SOL)
 - Arbitrum (ARB)
 - Base
@@ -304,6 +312,7 @@ Each chain has specific requirements:
 - Account must exist and be initialized
 - Sufficient NEAR for storage and gas
 - Token must be registered with account
+- Can use either near-api-js or Wallet Selector for interactions
 
 ### Ethereum/EVM
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Cross-chain transfers have different flows depending on the source and destinati
 
 ### NEAR to Foreign Chain Transfers
 
+> [!WARNING]
+> When using browser-based NEAR wallets through Wallet Selector, transactions involve page redirects. The current SDK doesn't fully support this flow - applications need to handle redirect returns and transaction hash parsing separately. This is a known limitation that will be addressed in a future update.
+
 When transferring from NEAR to another chain (e.g., Ethereum, Solana), you need to:
 
 1. Initiate the transfer on NEAR

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@ethereumjs/mpt": "7.0.0-alpha.1",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.1.0",
+    "@near-js/client": "^0.0.2",
+    "@near-wallet-selector/core": "^8.9.16",
     "@solana/spl-token": "^0.4.11",
     "@solana/web3.js": "^1.98.0",
     "@wormhole-foundation/sdk": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@ethereumjs/util':
         specifier: ^9.1.0
         version: 9.1.0
+      '@near-js/client':
+        specifier: ^0.0.2
+        version: 0.0.2
+      '@near-wallet-selector/core':
+        specifier: ^8.9.16
+        version: 8.9.16(near-api-js@5.0.1)
       '@solana/spl-token':
         specifier: ^0.4.11
         version: 0.4.12(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(utf-8-validate@5.0.10)
@@ -619,6 +625,9 @@ packages:
   '@near-js/accounts@1.3.1':
     resolution: {integrity: sha512-LAUN5L31JKtuXD9xS6D98GLtjG8KL9z761RvTYH6FMAwTFiyPed2M65mKNThGj3Zq46vWRGML0rJ2rlnXvewrA==}
 
+  '@near-js/client@0.0.2':
+    resolution: {integrity: sha512-L/H6IJGmjk3iaNt+tZQGDzlhF6LQvFjeUNLFxLPg1fOw71EmwssHroKDSo6Xowif9/twPslbNge0KOy1cplpHA==}
+
   '@near-js/crypto@1.4.1':
     resolution: {integrity: sha512-hbricJD0H8nwu63Zw16UZQg3ms2W9NwDBsLt3OEtudTcu9q1MRrVZWc7ATjdmTvhkcgmouEFc6oLBsOxnmSLCA==}
 
@@ -648,6 +657,11 @@ packages:
 
   '@near-js/wallet-account@1.3.1':
     resolution: {integrity: sha512-POOKarJnYsTK0zEXygm43ecGlraPl5qagQHl+By5bk0zQFgeKaoFIJK/n04xUoGBhZTBIVp1/q7q3O1pB57hqg==}
+
+  '@near-wallet-selector/core@8.9.16':
+    resolution: {integrity: sha512-Bq+bZvwpsYgs8g4mtDMEMUpHwD/+VlHY3hj5pLv6o6C/3Ym0/540/8ydd9VUhMsdpY0Dhv2SLamKiL6PJK6THA==}
+    peerDependencies:
+      near-api-js: ^4.0.0 || ^5.0.0
 
   '@noble/ciphers@1.2.1':
     resolution: {integrity: sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==}
@@ -1590,6 +1604,10 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -1854,6 +1872,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-fetch@3.0.0:
+    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
 
   isomorphic-unfetch@3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
@@ -2756,6 +2777,9 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3672,6 +3696,20 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@near-js/client@0.0.2':
+    dependencies:
+      '@near-js/crypto': 1.4.1
+      '@near-js/keystores': 0.2.1
+      '@near-js/providers': 1.0.1
+      '@near-js/signers': 0.2.1
+      '@near-js/transactions': 1.3.1
+      '@near-js/types': 0.3.1
+      '@near-js/utils': 1.0.1
+      '@noble/hashes': 1.3.3
+      isomorphic-fetch: 3.0.0
+    transitivePeerDependencies:
+      - encoding
+
   '@near-js/crypto@1.4.1':
     dependencies:
       '@near-js/types': 0.3.1
@@ -3746,6 +3784,14 @@ snapshots:
       borsh: 1.0.0
     transitivePeerDependencies:
       - encoding
+
+  '@near-wallet-selector/core@8.9.16(near-api-js@5.0.1)':
+    dependencies:
+      borsh: 1.0.0
+      events: 3.3.0
+      js-sha256: 0.9.0
+      near-api-js: 5.0.1
+      rxjs: 7.8.1
 
   '@noble/ciphers@1.2.1': {}
 
@@ -5012,6 +5058,8 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  events@3.3.0: {}
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -5284,9 +5332,16 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-fetch@3.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
+
   isomorphic-unfetch@3.1.0:
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.7.0
       unfetch: 4.2.0
     transitivePeerDependencies:
       - encoding
@@ -6141,6 +6196,8 @@ snapshots:
   vlq@2.0.4: {}
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-fetch@3.6.20: {}
 
   whatwg-url@5.0.0:
     dependencies:

--- a/src/clients/near-wallet-selector.ts
+++ b/src/clients/near-wallet-selector.ts
@@ -1,0 +1,652 @@
+import { callViewMethod, createRpcClientWrapper } from "@near-js/client"
+import type { WalletSelector } from "@near-wallet-selector/core"
+import { borshSerialize } from "borsher"
+import { JsonRpcProvider } from "near-api-js/lib/providers"
+import {
+  type AccountId,
+  type BindTokenArgs,
+  BindTokenArgsSchema,
+  ChainKind,
+  type DeployTokenArgs,
+  DeployTokenArgsSchema,
+  type EvmVerifyProofArgs,
+  EvmVerifyProofArgsSchema,
+  type FinTransferArgs,
+  FinTransferArgsSchema,
+  type InitTransferEvent,
+  type LogMetadataArgs,
+  type LogMetadataEvent,
+  type OmniAddress,
+  type OmniTransferMessage,
+  ProofKind,
+  type SignTransferArgs,
+  type SignTransferEvent,
+  type U128,
+  type WormholeVerifyProofArgs,
+  WormholeVerifyProofArgsSchema,
+} from "../types"
+import { getChain } from "../utils"
+
+/**
+ * Configuration for NEAR network gas limits.
+ * All values are specified in TGas (Terra Gas) units.
+ * @internal
+ */
+const GAS = {
+  LOG_METADATA: BigInt(3e14), // 3 TGas
+  DEPLOY_TOKEN: BigInt(1.2e14), // 1.2 TGas
+  BIND_TOKEN: BigInt(3e14), // 3 TGas
+  INIT_TRANSFER: BigInt(3e14), // 3 TGas
+  FIN_TRANSFER: BigInt(3e14), // 3 TGas
+  SIGN_TRANSFER: BigInt(3e14), // 3 TGas
+  STORAGE_DEPOSIT: BigInt(1e14), // 1 TGas
+} as const
+
+/**
+ * Configuration for NEAR network deposit amounts.
+ * Values represent the amount of NEAR tokens required for each operation.
+ * @internal
+ */
+const DEPOSIT = {
+  LOG_METADATA: BigInt(2e23), // 0.2 NEAR
+  DEPLOY_TOKEN: BigInt(4e24), // 4 NEAR
+  BIND_TOKEN: BigInt(2e23), // 0.2 NEAR
+  SIGN_TRANSFER: BigInt(5e23), // 0.5 NEAR
+  INIT_TRANSFER: BigInt(1), // 1 yoctoNEAR
+  FIN_TRANSFER: BigInt(1), // 1 yoctoNEAR
+} as const
+
+/**
+ * Represents the storage deposit balance for a NEAR account
+ */
+type StorageDeposit = {
+  total: bigint
+  available: bigint
+} | null
+
+interface InitTransferMessageArgs {
+  receiver_id: AccountId
+  memo: string | null
+  amount: string
+  msg: string | null
+}
+
+interface InitTransferMessage {
+  recipient: OmniAddress
+  fee: string
+  native_token_fee: string
+}
+
+/**
+ * Interface representing the results of various balance queries
+ * @property regBalance - Required balance for account registration
+ * @property initBalance - Required balance for initializing transfers
+ * @property finBalance - Required balance for finalizing transfers
+ * @property bindBalance - Required balance for binding tokens
+ * @property storage - Current storage deposit balance information
+ */
+interface BalanceResults {
+  regBalance: bigint
+  initBalance: bigint
+  finBalance: bigint
+  bindBalance: bigint
+  storage: StorageDeposit
+}
+
+/**
+ * NEAR blockchain implementation of the bridge client.
+ * Handles token deployment, binding, and transfer operations on the NEAR blockchain.
+ */
+export class NearWalletSelectorBridgeClient {
+  /**
+   * Creates a new NEAR bridge client instance
+   * @param selector - NEAR wallet selector instance for transaction signing
+   * @param lockerAddress - Address of the token locker contract
+   * @throws {Error} If locker address is not configured
+   */
+  constructor(
+    private selector: WalletSelector,
+    private lockerAddress: string = process.env.OMNI_BRIDGE_NEAR as string,
+  ) {
+    if (lockerAddress) {
+      this.lockerAddress = lockerAddress
+      return
+    }
+    const network = this.selector.options.network.networkId
+    if (network === "testnet") {
+      this.lockerAddress = "omni-locker.testnet"
+    } else if (network === "mainnet") {
+      this.lockerAddress = "omni.bridge.near"
+    }
+    if (!this.lockerAddress) {
+      throw new Error("OMNI_BRIDGE_NEAR address not configured")
+    }
+  }
+
+  /**
+   * Logs metadata for a token on the NEAR blockchain
+   * @param tokenAddress - Omni address of the token
+   * @throws {Error} If token address is not on NEAR chain
+   * @returns Promise resolving to the transaction hash
+   */
+  async logMetadata(tokenAddress: OmniAddress): Promise<LogMetadataEvent> {
+    if (getChain(tokenAddress) !== ChainKind.Near) {
+      throw new Error("Token address must be on NEAR")
+    }
+
+    const [_, tokenAccountId] = tokenAddress.split(":")
+    const args: LogMetadataArgs = { token_id: tokenAccountId }
+
+    const wallet = await this.selector.wallet()
+    const outcome = await wallet.signAndSendTransaction({
+      receiverId: this.lockerAddress,
+      actions: [
+        {
+          type: "FunctionCall",
+          params: {
+            methodName: "log_metadata",
+            args,
+            gas: GAS.LOG_METADATA.toString(),
+            deposit: DEPOSIT.LOG_METADATA.toString(),
+          },
+        },
+      ],
+    })
+    if (!outcome) {
+      throw new Error("Failed to log metadata")
+    }
+
+    // Parse event from transaction logs
+    const event = outcome.receipts_outcome
+      .flatMap((receipt) => receipt.outcome.logs)
+      .find((log) => log.includes("LogMetadataEvent"))
+
+    if (!event) {
+      throw new Error("LogMetadataEvent not found in transaction logs")
+    }
+
+    return JSON.parse(event).LogMetadataEvent
+  }
+
+  /**
+   * Deploys a token to the specified destination chain
+   * @param destinationChain - Target chain where the token will be deployed
+   * @param vaa - Verified Action Approval containing deployment information
+   * @returns Promise resolving to the transaction hash
+   */
+  async deployToken(destinationChain: ChainKind, vaa: string): Promise<string> {
+    const proverArgs: WormholeVerifyProofArgs = {
+      proof_kind: ProofKind.DeployToken,
+      vaa: vaa,
+    }
+    const proverArgsSerialized = borshSerialize(WormholeVerifyProofArgsSchema, proverArgs)
+
+    // Construct deploy token arguments
+    const args: DeployTokenArgs = {
+      chain_kind: destinationChain,
+      prover_args: proverArgsSerialized,
+    }
+    const serializedArgs = borshSerialize(DeployTokenArgsSchema, args)
+
+    const wallet = await this.selector.wallet()
+    const outcome = await wallet.signAndSendTransaction({
+      receiverId: this.lockerAddress,
+      actions: [
+        {
+          type: "FunctionCall",
+          params: {
+            methodName: "deploy_token",
+            args: serializedArgs,
+            gas: GAS.DEPLOY_TOKEN.toString(),
+            deposit: DEPOSIT.DEPLOY_TOKEN.toString(),
+          },
+        },
+      ],
+    })
+    if (!outcome) {
+      throw new Error("Failed to deploy token")
+    }
+
+    return outcome.transaction.hash
+  }
+
+  /**
+   * Binds a token on the NEAR chain using either a VAA (Wormhole) or EVM proof
+   * @param sourceChain - Source chain where the original token comes from
+   * @param vaa - Verified Action Approval for Wormhole verification
+   * @param evmProof - EVM proof for Ethereum or EVM chain verification
+   * @throws {Error} If VAA or EVM proof is not provided
+   * @throws {Error} If EVM proof is provided for non-EVM chain
+   * @returns Promise resolving to the transaction hash
+   */
+  async bindToken(
+    sourceChain: ChainKind,
+    vaa?: string,
+    evmProof?: EvmVerifyProofArgs,
+  ): Promise<string> {
+    if (!vaa && !evmProof) {
+      throw new Error("Must provide either VAA or EVM proof")
+    }
+
+    if (evmProof) {
+      if (
+        sourceChain !== ChainKind.Eth &&
+        sourceChain !== ChainKind.Arb &&
+        sourceChain !== ChainKind.Base
+      ) {
+        throw new Error("EVM proof is only valid for Ethereum, Arbitrum, or Base")
+      }
+    }
+
+    let proverArgsSerialized: Uint8Array = new Uint8Array(0)
+    if (vaa) {
+      const proverArgs: WormholeVerifyProofArgs = {
+        proof_kind: ProofKind.DeployToken,
+        vaa: vaa,
+      }
+      proverArgsSerialized = borshSerialize(WormholeVerifyProofArgsSchema, proverArgs)
+    } else if (evmProof) {
+      const proverArgs: EvmVerifyProofArgs = {
+        proof_kind: ProofKind.DeployToken,
+        proof: evmProof.proof,
+      }
+      proverArgsSerialized = borshSerialize(EvmVerifyProofArgsSchema, proverArgs)
+    }
+
+    // Construct bind token arguments
+    const args: BindTokenArgs = {
+      chain_kind: sourceChain,
+      prover_args: proverArgsSerialized,
+    }
+    const serializedArgs = borshSerialize(BindTokenArgsSchema, args)
+    const wallet = await this.selector.wallet()
+    const outcome = await wallet.signAndSendTransaction({
+      receiverId: this.lockerAddress,
+      actions: [
+        {
+          type: "FunctionCall",
+          params: {
+            methodName: "bind_token",
+            args: serializedArgs,
+            gas: GAS.BIND_TOKEN.toString(),
+            deposit: DEPOSIT.BIND_TOKEN.toString(),
+          },
+        },
+      ],
+    })
+    if (!outcome) {
+      throw new Error("Failed to bind token")
+    }
+    return outcome.transaction.hash
+  }
+
+  /**
+   * Transfers NEP-141 tokens to the token locker contract on NEAR.
+   * This transaction generates a proof that is subsequently used to mint
+   * corresponding tokens on the destination chain.
+   *
+   * @param token - Omni address of the NEP-141 token to transfer
+   * @param recipient - Recipient's Omni address on the destination chain where tokens will be minted
+   * @param amount - Amount of NEP-141 tokens to transfer
+   * @throws {Error} If token address is not on NEAR chain
+   * @returns Promise resolving to InitTransferEvent
+   */
+
+  async initTransfer(transfer: OmniTransferMessage): Promise<InitTransferEvent> {
+    if (getChain(transfer.tokenAddress) !== ChainKind.Near) {
+      throw new Error("Token address must be on NEAR")
+    }
+    const tokenAddress = transfer.tokenAddress.split(":")[1]
+
+    // First, check if the FT has the token locker contract registered for storage
+    await this.storageDepositForToken(tokenAddress)
+
+    // Now do the storage deposit dance for the locker itself
+    const { regBalance, initBalance, storage } = await this.getBalances()
+    const requiredBalance = regBalance + initBalance
+    const existingBalance = storage?.available ?? BigInt(0)
+
+    if (requiredBalance > existingBalance) {
+      const neededAmount = requiredBalance - existingBalance
+      const wallet = await this.selector.wallet()
+      const outcome = await wallet.signAndSendTransaction({
+        receiverId: this.lockerAddress,
+        actions: [
+          {
+            type: "FunctionCall",
+            params: {
+              methodName: "storage_deposit",
+              args: {},
+              gas: GAS.STORAGE_DEPOSIT.toString(),
+              deposit: neededAmount.toString(),
+            },
+          },
+        ],
+      })
+      if (!outcome) {
+        throw new Error("Failed to storage deposit")
+      }
+    }
+
+    const initTransferMessage: InitTransferMessage = {
+      recipient: transfer.recipient,
+      fee: transfer.fee.toString(),
+      native_token_fee: transfer.nativeFee.toString(),
+    }
+    const args: InitTransferMessageArgs = {
+      receiver_id: this.lockerAddress,
+      amount: transfer.amount.toString(),
+      memo: null,
+      msg: JSON.stringify(initTransferMessage),
+    }
+
+    const wallet = await this.selector.wallet()
+    const tx = await wallet.signAndSendTransaction({
+      receiverId: tokenAddress,
+      actions: [
+        {
+          type: "FunctionCall",
+          params: {
+            methodName: "ft_transfer_call",
+            args,
+            gas: GAS.INIT_TRANSFER.toString(),
+            deposit: DEPOSIT.INIT_TRANSFER.toString(),
+          },
+        },
+      ],
+    })
+    if (!tx) {
+      throw new Error("Transaction failed")
+    }
+
+    // Parse event from transaction logs
+    const event = tx.receipts_outcome
+      .flatMap((receipt) => receipt.outcome.logs)
+      .find((log) => log.includes("InitTransferEvent"))
+
+    if (!event) {
+      throw new Error("InitTransferEvent not found in transaction logs")
+    }
+    return JSON.parse(event).InitTransferEvent
+  }
+
+  /**
+   * Signs transfer using the token locker
+   * @param initTransferEvent - Transfer event of the previously-initiated transfer
+   * @param feeRecipient - Address of the fee recipient, can be the original sender or a relayer
+   * @returns Promise resolving to the transaction hash
+   */
+  async signTransfer(
+    initTransferEvent: InitTransferEvent,
+    feeRecipient: AccountId,
+  ): Promise<SignTransferEvent> {
+    const args: SignTransferArgs = {
+      transfer_id: {
+        origin_chain: "Near",
+        origin_nonce: initTransferEvent.transfer_message.origin_nonce,
+      },
+      fee_recipient: feeRecipient,
+      fee: {
+        fee: initTransferEvent.transfer_message.fee.fee,
+        native_fee: initTransferEvent.transfer_message.fee.native_fee,
+      },
+    }
+
+    const wallet = await this.selector.wallet()
+    const outcome = await wallet.signAndSendTransaction({
+      receiverId: this.lockerAddress,
+      actions: [
+        {
+          type: "FunctionCall",
+          params: {
+            methodName: "sign_transfer",
+            args,
+            gas: GAS.SIGN_TRANSFER.toString(),
+            deposit: DEPOSIT.SIGN_TRANSFER.toString(),
+          },
+        },
+      ],
+    })
+    if (!outcome) {
+      throw new Error("Failed to sign transfer")
+    }
+
+    // Parse event from transaction logs
+    const event = outcome.receipts_outcome
+      .flatMap((receipt) => receipt.outcome.logs)
+      .find((log) => log.includes("SignTransferEvent"))
+
+    if (!event) {
+      throw new Error("SignTransferEvent not found in transaction logs")
+    }
+
+    return JSON.parse(event).SignTransferEvent
+  }
+
+  /**
+   * Finalizes a cross-chain token transfer on NEAR by processing the transfer proof and managing storage deposits.
+   * Supports both Wormhole VAA and EVM proof verification for transfers from supported chains.
+   *
+   * @param token - The token identifier on NEAR where transferred tokens will be minted
+   * @param account - The recipient account ID on NEAR
+   * @param storageDepositAmount - Amount of NEAR tokens for storage deposit (in yoctoNEAR)
+   * @param sourceChain - The originating chain of the transfer
+   * @param vaa - Optional Wormhole Verified Action Approval containing transfer information
+   * @param evmProof - Optional proof data for transfers from EVM-compatible chains
+   *
+   * @throws {Error} When neither VAA nor EVM proof is provided
+   * @throws {Error} When EVM proof is provided for non-EVM chains (only valid for Ethereum, Arbitrum, or Base)
+   *
+   * @returns Promise resolving to the finalization transaction hash
+   *
+   */
+  async finalizeTransfer(
+    token: string,
+    account: string,
+    storageDepositAmount: U128,
+    sourceChain: ChainKind,
+    vaa?: string,
+    evmProof?: EvmVerifyProofArgs,
+  ): Promise<string> {
+    if (!vaa && !evmProof) {
+      throw new Error("Must provide either VAA or EVM proof")
+    }
+    if (evmProof) {
+      if (
+        sourceChain !== ChainKind.Eth &&
+        sourceChain !== ChainKind.Arb &&
+        sourceChain !== ChainKind.Base
+      ) {
+        throw new Error("EVM proof is only valid for Ethereum, Arbitrum, or Base")
+      }
+    }
+    let proverArgsSerialized: Uint8Array = new Uint8Array(0)
+    if (vaa) {
+      const proverArgs: WormholeVerifyProofArgs = {
+        proof_kind: ProofKind.DeployToken,
+        vaa: vaa,
+      }
+      proverArgsSerialized = borshSerialize(WormholeVerifyProofArgsSchema, proverArgs)
+    } else if (evmProof) {
+      const proverArgs: EvmVerifyProofArgs = {
+        proof_kind: ProofKind.DeployToken,
+        proof: evmProof.proof,
+      }
+      proverArgsSerialized = borshSerialize(EvmVerifyProofArgsSchema, proverArgs)
+    }
+
+    const args: FinTransferArgs = {
+      chain_kind: sourceChain,
+      storage_deposit_actions: [
+        {
+          token_id: token,
+          account_id: account,
+          storage_deposit_amount: storageDepositAmount,
+        },
+      ],
+      prover_args: proverArgsSerialized,
+    }
+    const serializedArgs = borshSerialize(FinTransferArgsSchema, args)
+
+    const wallet = await this.selector.wallet()
+    const outcome = await wallet.signAndSendTransaction({
+      receiverId: this.lockerAddress,
+      actions: [
+        {
+          type: "FunctionCall",
+          params: {
+            methodName: "finalize_transfer",
+            args: serializedArgs,
+            gas: GAS.FIN_TRANSFER.toString(),
+            deposit: DEPOSIT.FIN_TRANSFER.toString(),
+          },
+        },
+      ],
+    })
+    if (!outcome) {
+      throw new Error("Failed to finalize transfer")
+    }
+    return outcome.transaction.hash
+  }
+
+  /**
+   * Retrieves various balance information for the current account
+   * @private
+   * @returns Promise resolving to object containing required balances and storage information
+   * @throws {Error} If balance fetching fails
+   */
+  private async getBalances(): Promise<BalanceResults> {
+    try {
+      const wallet = await this.selector.wallet()
+      const accounts = await wallet.getAccounts()
+      const accountId = accounts[0].accountId
+      const { network } = this.selector.options
+      const provider = new JsonRpcProvider({ url: network.nodeUrl })
+      provider.query({
+        request_type: "view_account",
+        finality: "final",
+        account_id: accountId,
+      })
+
+      const [regBalanceStr, initBalanceStr, finBalanceStr, bindBalanceStr, storage] =
+        await Promise.all([
+          this.viewFunction({
+            contractId: this.lockerAddress,
+            methodName: "required_balance_for_account",
+          }),
+          this.viewFunction({
+            contractId: this.lockerAddress,
+            methodName: "required_balance_for_init_transfer",
+          }),
+          this.viewFunction({
+            contractId: this.lockerAddress,
+            methodName: "required_balance_for_fin_transfer",
+            args: {
+              account_id: accountId,
+            },
+          }),
+          this.viewFunction({
+            contractId: this.lockerAddress,
+            methodName: "required_balance_for_bind_token",
+            args: {
+              account_id: accountId,
+            },
+          }),
+          this.viewFunction({
+            contractId: this.lockerAddress,
+            methodName: "storage_balance_of",
+            args: {
+              account_id: accountId,
+            },
+          }),
+        ])
+
+      // Convert storage balance to bigint
+      let convertedStorage = null
+      if (storage) {
+        convertedStorage = {
+          total: BigInt(storage.total),
+          available: BigInt(storage.available),
+        }
+      }
+
+      return {
+        regBalance: BigInt(regBalanceStr),
+        initBalance: BigInt(initBalanceStr),
+        finBalance: BigInt(finBalanceStr),
+        bindBalance: BigInt(bindBalanceStr),
+        storage: convertedStorage,
+      }
+    } catch (error) {
+      console.error("Error fetching balances:", error)
+      throw error
+    }
+  }
+
+  private async viewFunction({
+    contractId,
+    methodName,
+    args = {},
+  }: {
+    contractId: string
+    methodName: string
+    args?: object
+    // biome-ignore lint/suspicious/noExplicitAny: Arbitrary types needed for JSON response
+  }): Promise<any> {
+    const { network } = this.selector.options
+    const rpcProvider = createRpcClientWrapper([network.nodeUrl])
+
+    const res = await callViewMethod({
+      account: contractId,
+      method: methodName,
+      args,
+      deps: { rpcProvider },
+    })
+    return JSON.parse(Buffer.from(res.result).toString())
+  }
+
+  /// Performs a storage deposit on behalf of the token_locker so that the tokens can be transferred to the locker. To be called once for each NEP-141
+  private async storageDepositForToken(tokenAddress: string): Promise<string> {
+    const storage = await this.viewFunction({
+      contractId: tokenAddress,
+      methodName: "storage_balance_of",
+      args: {
+        account_id: this.lockerAddress,
+      },
+    })
+    if (storage === null) {
+      // Check how much is required
+      const bounds = await this.viewFunction({
+        contractId: tokenAddress,
+        methodName: "storage_balance_bounds",
+        args: {
+          account_id: this.lockerAddress,
+        },
+      })
+      const requiredAmount = BigInt(bounds.min)
+
+      const wallet = await this.selector.wallet()
+      const outcome = await wallet.signAndSendTransaction({
+        receiverId: tokenAddress,
+        actions: [
+          {
+            type: "FunctionCall",
+            params: {
+              methodName: "storage_deposit",
+              args: {
+                account_id: this.lockerAddress,
+              },
+              gas: GAS.STORAGE_DEPOSIT.toString(),
+              deposit: requiredAmount.toString(),
+            },
+          },
+        ],
+      })
+      if (!outcome) {
+        throw new Error("Failed to storage deposit")
+      }
+      return outcome.transaction.hash
+    }
+    return storage
+  }
+}

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,8 +1,10 @@
 import type { AnchorProvider } from "@coral-xyz/anchor"
+import type { WalletSelector } from "@near-wallet-selector/core"
 import type { ethers } from "ethers"
-import type { Account } from "near-api-js"
+import { Account } from "near-api-js"
 import { EvmBridgeClient } from "./clients/evm"
 import { NearBridgeClient } from "./clients/near"
+import { NearWalletSelectorBridgeClient } from "./clients/near-wallet-selector"
 import { SolanaBridgeClient } from "./clients/solana"
 import { ChainKind } from "./types"
 
@@ -23,7 +25,10 @@ import { ChainKind } from "./types"
 export function getClient<TWallet>(chain: ChainKind, wallet: TWallet) {
   switch (chain) {
     case ChainKind.Near:
-      return new NearBridgeClient(wallet as Account)
+      if (wallet instanceof Account) {
+        return new NearBridgeClient(wallet as Account)
+      }
+      return new NearWalletSelectorBridgeClient(wallet as WalletSelector)
     case ChainKind.Eth:
     case ChainKind.Base:
     case ChainKind.Arb:


### PR DESCRIPTION
# Add support for NEAR Wallet Selector
> [!WARNING]
> Browser-based NEAR wallets use page redirects for transaction signing. The current implementation doesn't properly handle these redirects, making it impossible to get transaction outcomes directly. Applications need to handle redirect returns with transaction hashes in URL parameters. This needs to be addressed in a future update.

## Overview
This PR adds support for NEAR Wallet Selector as an alternative to NEAR Account for NEAR chain interactions. This enhancement provides more flexibility for dApps that prefer using Wallet Selector over direct NEAR Account integration.

## Changes
- Added new `NearWalletSelectorBridgeClient` implementation
- Updated factory to support both NEAR Account and Wallet Selector
- Added necessary dependencies (`@near-js/client` and `@near-wallet-selector/core`)
- Updated documentation with Wallet Selector examples
- Maintained full backwards compatibility with existing NEAR Account implementation

## Implementation Details
The new `NearWalletSelectorBridgeClient` implements all core functionality:
- Token deployment and binding
- Transfer initiation and finalization
- Storage deposit management
- Fee calculations
- Metadata logging

All methods support both Wormhole VAA and EVM proof verification where applicable.


## Usage Example
```typescript
// Initialize Wallet Selector
const selector = await setupWalletSelector({
  network: "testnet",
  modules: [/* wallet modules */],
});

// Create client using Wallet Selector
const client = getClient(ChainKind.Near, selector);

// Use exactly like NEAR Account client
const transfer = {
  tokenAddress: omniAddress(ChainKind.Near, "usdc.near"),
  amount: BigInt("1000000"),
  recipient: omniAddress(ChainKind.Eth, ethAddress),
};
const result = await client.initTransfer(transfer);
```

## Migration Notes
No migration required. Existing NEAR Account implementations will continue to work without changes. Developers can opt-in to using Wallet Selector by passing a selector instance to `getClient` instead of a NEAR Account.

## Documentation
- Updated README with Wallet Selector examples
- Added inline documentation for new client implementation
- Updated type definitions