### PR TITLE
Improve NEAR token transfer handling and fix Solana provider type issues

### DIFF
--- a/.changeset/fuzzy-glasses-smash.md
+++ b/.changeset/fuzzy-glasses-smash.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+fix: update Solana Provider type and add type guards

--- a/.changeset/warm-moles-explode.md
+++ b/.changeset/warm-moles-explode.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": minor
+---
+
+feat: batch storage deposit with transfer for NEAR transactions

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import { AnchorProvider as SolWallet } from "@coral-xyz/anchor"
+import type { Provider as SolWallet } from "@coral-xyz/anchor"
 import type { WalletSelector } from "@near-wallet-selector/core"
 import { Wallet as EthWallet } from "ethers"
 import { Account as NearAccount } from "near-api-js"
@@ -14,18 +14,35 @@ type Client =
   | NearWalletSelectorBridgeClient
   | SolanaBridgeClient
 
+// Type guards
+export function isSolWallet(wallet: SolWallet | WalletSelector): wallet is SolWallet {
+  return (
+    wallet && typeof wallet === "object" && "publicKey" in wallet && "sendTransaction" in wallet
+  )
+}
+
+export function isWalletSelector(wallet: SolWallet | WalletSelector): wallet is WalletSelector {
+  return (
+    wallet &&
+    typeof wallet === "object" &&
+    "wallet" in wallet &&
+    typeof wallet.wallet === "function"
+  )
+}
+
 export async function omniTransfer(
   wallet: EthWallet | NearAccount | WalletSelector | SolWallet,
   transfer: OmniTransferMessage,
 ): Promise<string | InitTransferEvent> {
   let client: Client | null = null
-  if (wallet instanceof NearAccount) {
-    client = new NearBridgeClient(wallet)
-  } else if (wallet instanceof EthWallet) {
+
+  if (wallet instanceof EthWallet) {
     client = new EvmBridgeClient(wallet, ChainKind.Eth)
-  } else if (wallet instanceof SolWallet) {
+  } else if (wallet instanceof NearAccount) {
+    client = new NearBridgeClient(wallet)
+  } else if (isSolWallet(wallet)) {
     client = new SolanaBridgeClient(wallet)
-  } else {
+  } else if (isWalletSelector(wallet)) {
     client = new NearWalletSelectorBridgeClient(wallet)
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,4 +1,4 @@
-import type { AnchorProvider } from "@coral-xyz/anchor"
+import type { Provider } from "@coral-xyz/anchor"
 import type { WalletSelector } from "@near-wallet-selector/core"
 import type { ethers } from "ethers"
 import { Account } from "near-api-js"
@@ -24,7 +24,7 @@ import { ChainKind } from "./types"
  */
 export function getClient(
   chain: ChainKind,
-  wallet: Account | WalletSelector | ethers.Signer | AnchorProvider,
+  wallet: Account | WalletSelector | ethers.Signer | Provider,
 ) {
   switch (chain) {
     case ChainKind.Near:
@@ -37,7 +37,7 @@ export function getClient(
     case ChainKind.Arb:
       return new EvmBridgeClient(wallet as ethers.Signer, chain)
     case ChainKind.Sol:
-      return new SolanaBridgeClient(wallet as AnchorProvider)
+      return new SolanaBridgeClient(wallet as Provider)
     default:
       throw new Error(`No client implementation for chain: ${chain}`)
   }


### PR DESCRIPTION
This PR includes two main changes:

1. Fixes Solana provider type mismatch by:
- Replacing `AnchorProvider` with more generic `Provider` type
- Adding type guards to properly handle wallet type checks
- Updating client initialization logic to use type guards

2. Improves NEAR token transfer reliability by:
- Batching storage deposit operations with the main transfer transaction
- Adding transaction error handling and event parsing for batch operations
- Moving storage deposit logic into a separate reusable method