### PR TITLE
Network Address Configuration Refactor

### DIFF
--- a/.changeset/shiny-lies-refuse.md
+++ b/.changeset/shiny-lies-refuse.md
@@ -1,0 +1,10 @@
+---
+"omni-bridge-sdk": minor
+---
+
+Add centralized network address configuration:
+
+- Add new `config.ts` module with mainnet/testnet addresses
+- Add `setNetwork()` function for network selection
+- Remove environment variable dependencies for addresses
+- Update all clients to use centralized config

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The fastest way to get started is using our relayer service for automated transf
 import { omniTransfer, OmniBridgeAPI } from "omni-bridge-sdk";
 
 // Get fees (includes relayer service fee)
-const api = new OmniBridgeAPI("testnet");
+const api = new OmniBridgeAPI();
 const fees = await api.getFee("eth:0x123...", "near:bob.near", "eth:0x789...");
 
 // Send tokens
@@ -77,7 +77,7 @@ const account = await near.account("sender.near"); // for NEAR
 const provider = new AnchorProvider(connection, wallet); // for Solana
 
 // 2. Get fees (includes relayer service fee)
-const api = new OmniBridgeAPI("testnet");
+const api = new OmniBridgeAPI();
 const sender = "eth:0x123...";
 const recipient = "near:bob.near";
 const token = "eth:0x789...";
@@ -166,7 +166,7 @@ const result = await omniTransfer(account, transfer);
 Track transfer progress using the API:
 
 ```typescript
-const api = new OmniBridgeAPI("testnet");
+const api = new OmniBridgeAPI();
 const status = await api.getTransferStatus(sourceChain, nonce);
 // Status: "pending" | "ready_for_finalize" | "completed" | "failed"
 
@@ -181,7 +181,7 @@ const transfers = await api.findOmniTransfers(
 ### Fee Estimation
 
 ```typescript
-const api = new OmniBridgeAPI("testnet");
+const api = new OmniBridgeAPI();
 const fee = await api.getFee(sender, recipient, tokenAddr);
 
 console.log(`Native fee: ${fee.native_token_fee}`); // Includes relayer fee

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ await omniTransfer(wallet, {
 Here's a more detailed example showing wallet setup, error handling, and status monitoring:
 
 ```typescript
+import { setNetwork } from "omni-bridge-sdk";
+
+// Set network type
+setNetwork("testnet");
+
 // 1. Setup wallet/provider
 const wallet = provider.getSigner(); // for EVM
 // or

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "vitest",
     "lint": "biome check --write .",
     "typecheck": "tsc --noEmit",
-    "prepare": "pnpm run build",
     "prepublishOnly": "pnpm build",
     "lefthook": "lefthook install",
     "check-exports": "attw --pack .",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,4 @@
+import { getNetwork } from "./config"
 import type { OmniAddress } from "./types"
 
 // Types from OpenAPI spec
@@ -47,21 +48,23 @@ export interface ApiFeeResponse {
 export type TransferStatus = "Initialized" | "FinalisedOnNear" | "Finalised"
 
 export class OmniBridgeAPI {
-  private baseUrl: string
+  private baseUrl?: string
 
-  constructor(network: "testnet" | "mainnet") {
-    this.baseUrl =
-      network === "testnet"
-        ? "https://testnet.api.bridge.nearone.org"
-        : "https://api.bridge.nearone.org"
+  constructor(baseUrl?: string) {
+    this.baseUrl = baseUrl
   }
 
   public getBaseUrl(): string {
-    return this.baseUrl
+    if (this.baseUrl) {
+      return this.baseUrl
+    }
+    return getNetwork() === "testnet"
+      ? "https://testnet.api.bridge.nearone.org"
+      : "https://api.bridge.nearone.org"
   }
 
   async getTransferStatus(originChain: Chain, originNonce: number): Promise<TransferStatus> {
-    const url = new URL(`${this.baseUrl}/api/v1/transfers/transfer/status`)
+    const url = new URL(`${this.getBaseUrl()}/api/v1/transfers/transfer/status`)
     url.searchParams.set("origin_chain", originChain)
     url.searchParams.set("origin_nonce", originNonce.toString())
 
@@ -84,7 +87,7 @@ export class OmniBridgeAPI {
     recipient: OmniAddress,
     tokenAddress: string,
   ): Promise<ApiFeeResponse> {
-    const url = new URL(`${this.baseUrl}/api/v1/transfer-fee`)
+    const url = new URL(`${this.getBaseUrl()}/api/v1/transfer-fee`)
     url.searchParams.set("sender", sender)
     url.searchParams.set("recipient", recipient)
     url.searchParams.set("token", tokenAddress)
@@ -100,7 +103,7 @@ export class OmniBridgeAPI {
   }
 
   async getTransfer(originChain: Chain, originNonce: number): Promise<Transfer> {
-    const url = new URL(`${this.baseUrl}/api/v1/transfers/transfer`)
+    const url = new URL(`${this.getBaseUrl()}/api/v1/transfers/transfer`)
     url.searchParams.set("origin_chain", originChain)
     url.searchParams.set("origin_nonce", originNonce.toString())
 
@@ -113,7 +116,7 @@ export class OmniBridgeAPI {
   }
 
   async findOmniTransfers(sender: OmniAddress, offset: number, limit: number): Promise<Transfer[]> {
-    const url = new URL(`${this.baseUrl}/api/v1/transfers`)
+    const url = new URL(`${this.getBaseUrl()}/api/v1/transfers`)
     url.searchParams.set("sender", sender)
     url.searchParams.set("offset", offset.toString())
     url.searchParams.set("limit", limit.toString())

--- a/src/clients/evm.ts
+++ b/src/clients/evm.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers"
+import { addresses } from "../config"
 import type {
   BridgeDeposit,
   ChainKind,
@@ -59,15 +60,6 @@ const GAS_LIMIT = {
 } as const
 
 /**
- * Factory addresses for different chains mapped by chain tag
- */
-const FACTORY_ADDRESSES: Record<ChainTag<EVMChainKind>, string | undefined> = {
-  Eth: process.env.OMNI_FACTORY_ETH,
-  Base: process.env.OMNI_FACTORY_BASE,
-  Arb: process.env.OMNI_FACTORY_ARBITRUM,
-}
-
-/**
  * EVM blockchain implementation of the bridge client
  */
 export class EvmBridgeClient {
@@ -91,13 +83,24 @@ export class EvmBridgeClient {
 
     this.chainKind = chain
     this.chainTag = ChainUtils.getTag(chain)
-    const factoryAddress = FACTORY_ADDRESSES[this.chainTag]
 
-    if (!factoryAddress) {
-      throw new Error(`Factory address not configured for chain ${this.chainTag}`)
+    // Get Omni Bridge address from global config based on chain
+    let bridgeAddress: string
+    switch (this.chainTag) {
+      case "Eth":
+        bridgeAddress = addresses.eth
+        break
+      case "Base":
+        bridgeAddress = addresses.base
+        break
+      case "Arb":
+        bridgeAddress = addresses.arb
+        break
+      default:
+        throw new Error(`Factory address not configured for chain ${this.chainTag}`)
     }
 
-    this.factory = new ethers.Contract(factoryAddress, BRIDGE_TOKEN_FACTORY_ABI, this.wallet)
+    this.factory = new ethers.Contract(bridgeAddress, BRIDGE_TOKEN_FACTORY_ABI, this.wallet)
   }
 
   /**

--- a/src/clients/near-wallet-selector.ts
+++ b/src/clients/near-wallet-selector.ts
@@ -2,6 +2,7 @@ import { callViewMethod, createRpcClientWrapper } from "@near-js/client"
 import type { Optional, Transaction, WalletSelector } from "@near-wallet-selector/core"
 import { borshSerialize } from "borsher"
 import { JsonRpcProvider } from "near-api-js/lib/providers"
+import { addresses } from "../config"
 import {
   type AccountId,
   type BindTokenArgs,
@@ -106,7 +107,7 @@ export class NearWalletSelectorBridgeClient {
    */
   constructor(
     private selector: WalletSelector,
-    private lockerAddress: string = process.env.OMNI_BRIDGE_NEAR as string,
+    private lockerAddress: string = addresses.near,
   ) {
     if (lockerAddress) {
       this.lockerAddress = lockerAddress

--- a/src/clients/near.ts
+++ b/src/clients/near.ts
@@ -1,6 +1,7 @@
 import { borshSerialize } from "borsher"
 import type { Account } from "near-api-js"
 import { functionCall } from "near-api-js/lib/transaction"
+import { addresses } from "../config"
 import {
   type AccountId,
   type BindTokenArgs,
@@ -105,7 +106,7 @@ export class NearBridgeClient {
    */
   constructor(
     private wallet: Account,
-    private lockerAddress: string = process.env.OMNI_BRIDGE_NEAR as string,
+    private lockerAddress: string = addresses.near,
   ) {
     if (lockerAddress) {
       this.lockerAddress = lockerAddress

--- a/src/clients/solana.ts
+++ b/src/clients/solana.ts
@@ -47,9 +47,15 @@ export class SolanaBridgeClient {
     SOL_VAULT: this.getConstant("SOL_VAULT_SEED"),
   }
 
-  constructor(provider: Provider, wormholeProgramId: PublicKey = new PublicKey(addresses.sol)) {
+  constructor(
+    provider: Provider,
+    wormholeProgramId: PublicKey = new PublicKey(addresses.sol.wormhole),
+  ) {
     this.wormholeProgramId = wormholeProgramId
-    this.program = new Program(BRIDGE_TOKEN_FACTORY_IDL as BridgeTokenFactory, provider)
+    const bridgeTokenFactory = BRIDGE_TOKEN_FACTORY_IDL as BridgeTokenFactory
+    // @ts-ignore We have to override the address for Mainnet/Testnet
+    bridgeTokenFactory.address = addresses.sol.locker
+    this.program = new Program(bridgeTokenFactory, provider)
   }
 
   private config(): [PublicKey, number] {

--- a/src/clients/solana.ts
+++ b/src/clients/solana.ts
@@ -9,6 +9,7 @@ import {
   SYSVAR_RENT_PUBKEY,
   SystemProgram,
 } from "@solana/web3.js"
+import { addresses } from "../config"
 import {
   ChainKind,
   type DepositPayload,
@@ -46,10 +47,7 @@ export class SolanaBridgeClient {
     SOL_VAULT: this.getConstant("SOL_VAULT_SEED"),
   }
 
-  constructor(
-    provider: Provider,
-    wormholeProgramId: PublicKey = new PublicKey(process.env.WORMHOLE_SOL as string),
-  ) {
+  constructor(provider: Provider, wormholeProgramId: PublicKey = new PublicKey(addresses.sol)) {
     this.wormholeProgramId = wormholeProgramId
     this.program = new Program(BRIDGE_TOKEN_FACTORY_IDL as BridgeTokenFactory, provider)
   }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { addresses, setNetwork } from "../src/config"
+import { OmniBridgeAPI } from "./api"
 
 describe("Config", () => {
   beforeEach(() => {
@@ -32,5 +33,12 @@ describe("Config", () => {
     expect(addresses.eth).toBe("0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8")
     expect(addresses.near).toBe("omni-locker.testnet")
     expect(addresses.sol).toBe("Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p")
+  })
+
+  it("should set the base URL for OmniBridgeAPI", () => {
+    const api = new OmniBridgeAPI()
+    expect(api.getBaseUrl()).toBe("https://api.bridge.nearone.org")
+    setNetwork("testnet")
+    expect(api.getBaseUrl()).toBe("https://testnet.api.bridge.nearone.org")
   })
 })

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -23,7 +23,7 @@ describe("Config", () => {
     expect(addresses.base).toBe("0xd025b38762B4A4E36F0Cde483b86CB13ea00D989")
     expect(addresses.eth).toBe("0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8")
     expect(addresses.near).toBe("omni.bridge.near")
-    expect(addresses.sol).toBe("dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe")
+    expect(addresses.sol.locker).toBe("dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe")
   })
 
   it("should return the correct addresses for testnet", () => {
@@ -32,7 +32,7 @@ describe("Config", () => {
     expect(addresses.base).toBe("0x0C981337fFe39a555d3A40dbb32f21aD0eF33FFA")
     expect(addresses.eth).toBe("0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8")
     expect(addresses.near).toBe("omni-locker.testnet")
-    expect(addresses.sol).toBe("Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p")
+    expect(addresses.sol.locker).toBe("Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p")
   })
 
   it("should set the base URL for OmniBridgeAPI", () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { addresses, setNetwork } from "../src/config"
+
+describe("Config", () => {
+  beforeEach(() => {
+    // Reset to mainnet before each test
+    setNetwork("mainnet")
+  })
+
+  it("should set the network to testnet", () => {
+    setNetwork("testnet")
+    expect(addresses.near).toBe("omni-locker.testnet")
+  })
+
+  it("should set the network to mainnet", () => {
+    setNetwork("mainnet")
+    expect(addresses.near).toBe("omni.bridge.near")
+  })
+
+  it("should return the correct addresses for mainnet", () => {
+    expect(addresses.arb).toBe("0xd025b38762B4A4E36F0Cde483b86CB13ea00D989")
+    expect(addresses.base).toBe("0xd025b38762B4A4E36F0Cde483b86CB13ea00D989")
+    expect(addresses.eth).toBe("0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8")
+    expect(addresses.near).toBe("omni.bridge.near")
+    expect(addresses.sol).toBe("dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe")
+  })
+
+  it("should return the correct addresses for testnet", () => {
+    setNetwork("testnet")
+    expect(addresses.arb).toBe("0xd025b38762B4A4E36F0Cde483b86CB13ea00D989")
+    expect(addresses.base).toBe("0x0C981337fFe39a555d3A40dbb32f21aD0eF33FFA")
+    expect(addresses.eth).toBe("0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8")
+    expect(addresses.near).toBe("omni-locker.testnet")
+    expect(addresses.sol).toBe("Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p")
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,10 @@ export function setNetwork(network: NetworkType) {
   selectedNetwork = network
 }
 
+export function getNetwork(): NetworkType {
+  return selectedNetwork
+}
+
 export const addresses = {
   get arb() {
     return ADDRESSES[selectedNetwork].arb

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,42 @@
+export type NetworkType = "mainnet" | "testnet"
+
+const ADDRESSES = {
+  mainnet: {
+    arb: "0xd025b38762B4A4E36F0Cde483b86CB13ea00D989",
+    base: "0xd025b38762B4A4E36F0Cde483b86CB13ea00D989",
+    eth: "0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8",
+    near: "omni.bridge.near",
+    sol: "dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe",
+  },
+  testnet: {
+    arb: "0xd025b38762B4A4E36F0Cde483b86CB13ea00D989",
+    base: "0x0C981337fFe39a555d3A40dbb32f21aD0eF33FFA",
+    eth: "0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8",
+    near: "omni-locker.testnet",
+    sol: "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p",
+  },
+} as const
+
+let selectedNetwork: NetworkType = "mainnet"
+
+export function setNetwork(network: NetworkType) {
+  selectedNetwork = network
+}
+
+export const addresses = {
+  get arb() {
+    return ADDRESSES[selectedNetwork].arb
+  },
+  get base() {
+    return ADDRESSES[selectedNetwork].base
+  },
+  get eth() {
+    return ADDRESSES[selectedNetwork].eth
+  },
+  get near() {
+    return ADDRESSES[selectedNetwork].near
+  },
+  get sol() {
+    return ADDRESSES[selectedNetwork].sol
+  },
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,14 +6,20 @@ const ADDRESSES = {
     base: "0xd025b38762B4A4E36F0Cde483b86CB13ea00D989",
     eth: "0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8",
     near: "omni.bridge.near",
-    sol: "dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe",
+    sol: {
+      locker: "dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe",
+      wormhole: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth",
+    },
   },
   testnet: {
     arb: "0xd025b38762B4A4E36F0Cde483b86CB13ea00D989",
     base: "0x0C981337fFe39a555d3A40dbb32f21aD0eF33FFA",
     eth: "0x3701B9859Dbb9a4333A3dd933ab18e9011ddf2C8",
     near: "omni-locker.testnet",
-    sol: "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p",
+    sol: {
+      locker: "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p",
+      wormhole: "Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o",
+    },
   },
 } as const
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,5 @@ export * from "./clients"
 
 // Export proofs
 export * from "./proofs"
+
+export * from "./config"

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2,8 +2,10 @@ import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
 import { OmniBridgeAPI } from "../src/api"
+import { setNetwork } from "../src/config"
 
-const api = new OmniBridgeAPI("testnet")
+setNetwork("testnet")
+const api = new OmniBridgeAPI()
 const BASE_URL = "https://testnet.api.bridge.nearone.org"
 
 // Mock data

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { OmniBridgeAPI } from "../../src/api"
+import { setNetwork } from "../../src/config"
 import { ChainKind, type OmniAddress } from "../../src/types"
 import { omniAddress } from "../../src/utils"
 
@@ -7,7 +8,8 @@ describe("OmniBridgeAPI Integration Tests", () => {
   let api: OmniBridgeAPI
 
   beforeEach(() => {
-    api = new OmniBridgeAPI("testnet")
+    setNetwork("testnet")
+    api = new OmniBridgeAPI()
   })
 
   describe.skip("getFee", () => {


### PR DESCRIPTION
## Changes
- Centralizes all network addresses in a new `config.ts` module
- Removes environment variable dependencies for network addresses
- Adds support for dynamic mainnet/testnet network selection
- Updates all clients (EVM, NEAR, Solana) to use the new config
- Updates README to document the new network configuration

## Why
- Improves maintainability by having a single source of truth for addresses
- Makes network switching more reliable by removing env var dependencies
- Simplifies testing by making network configuration programmatic
- Reduces deployment complexity by eliminating need for multiple env files

## Breaking Changes
Users will need to:
1. Remove OMNI_* address environment variables
2. Add `setNetwork()` call to specify network type
3. Update OmniBridgeAPI initialization to remove network parameter