### PR TITLE
Storage Deposit Fix & Solana IDL Update

### DIFF
--- a/.changeset/chatty-suns-fly.md
+++ b/.changeset/chatty-suns-fly.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": minor
+---
+
+feat(solana): update bridge implementation with message support, pause functionality, new admin roles, and updated testnet contract address

--- a/.changeset/wicked-fireants-end.md
+++ b/.changeset/wicked-fireants-end.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+fix(near): include native fee in storage deposit calculations

--- a/src/clients/near-wallet-selector.ts
+++ b/src/clients/near-wallet-selector.ts
@@ -334,9 +334,9 @@ export class NearWalletSelectorBridgeClient {
     const { regBalance, initBalance, storage } = await this.getBalances()
     const requiredBalance = regBalance + initBalance
     const existingBalance = storage?.available ?? BigInt(0)
+    const neededAmount = requiredBalance - existingBalance + transfer.nativeFee
 
-    if (requiredBalance > existingBalance) {
-      const neededAmount = requiredBalance - existingBalance
+    if (neededAmount > 0) {
       transactions.push({
         receiverId: this.lockerAddress,
         actions: [

--- a/src/clients/near.ts
+++ b/src/clients/near.ts
@@ -288,9 +288,9 @@ export class NearBridgeClient {
     const { regBalance, initBalance, storage } = await this.getBalances()
     const requiredBalance = regBalance + initBalance
     const existingBalance = storage?.available ?? BigInt(0)
+    const neededAmount = requiredBalance - existingBalance + transfer.nativeFee
 
-    if (requiredBalance > existingBalance) {
-      const neededAmount = requiredBalance - existingBalance
+    if (neededAmount > 0) {
       await this.wallet.functionCall({
         contractId: this.lockerAddress,
         methodName: "storage_deposit",

--- a/src/clients/solana.ts
+++ b/src/clients/solana.ts
@@ -251,6 +251,7 @@ export class SolanaBridgeClient {
           recipient: transfer.recipient,
           fee: new BN(transfer.fee.valueOf().toString()),
           nativeFee: new BN(transfer.nativeFee.valueOf().toString()),
+          message: "",
         })
         .accountsStrict({
           solVault,
@@ -282,6 +283,7 @@ export class SolanaBridgeClient {
           recipient: transfer.recipient,
           fee: new BN(transfer.fee.valueOf().toString()),
           nativeFee: new BN(transfer.nativeFee.valueOf().toString()),
+          message: "",
         })
         .accountsStrict({
           authority: this.authority()[0],

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ const ADDRESSES = {
     near: "omni-locker.testnet",
     sol: {
       locker: "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p",
-      wormhole: "Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o",
+      wormhole: "3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5",
     },
   },
 } as const

--- a/src/types/solana/bridge_token_factory.json
+++ b/src/types/solana/bridge_token_factory.json
@@ -119,7 +119,7 @@
             {
               "name": "sequence",
               "docs": [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable."
               ],
@@ -325,7 +325,7 @@
             {
               "name": "sequence",
               "docs": [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable."
               ],
@@ -505,7 +505,7 @@
             {
               "name": "sequence",
               "docs": [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable."
               ],
@@ -687,7 +687,7 @@
             {
               "name": "sequence",
               "docs": [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable."
               ],
@@ -822,7 +822,7 @@
             {
               "name": "sequence",
               "docs": [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable."
               ],
@@ -958,7 +958,7 @@
         {
           "name": "wormhole_sequence",
           "docs": [
-            "message is posted, so it needs to be an [UncheckedAccount] for the",
+            "message is posted, so it needs to be an [`UncheckedAccount`] for the",
             "[`initialize`](crate::initialize) instruction.",
             "[`wormhole::post_message`] requires this account be mutable."
           ],
@@ -1012,6 +1012,10 @@
       "args": [
         {
           "name": "admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "pausable_admin",
           "type": "pubkey"
         },
         {
@@ -1111,7 +1115,7 @@
             {
               "name": "sequence",
               "docs": [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable."
               ],
@@ -1172,6 +1176,117 @@
         }
       ],
       "args": []
+    },
+    {
+      "name": "pause",
+      "discriminator": [211, 22, 221, 251, 74, 121, 193, 47],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "set_admin",
+      "discriminator": [251, 163, 0, 52, 91, 194, 187, 92],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_pausable_admin",
+      "discriminator": [128, 59, 6, 173, 50, 0, 213, 197],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "pausable_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "unpause",
+      "discriminator": [169, 144, 4, 38, 10, 141, 188, 255],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "paused",
+          "type": "u8"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -1224,6 +1339,16 @@
       "code": 6007,
       "name": "InvalidFee",
       "msg": "Invalid fee"
+    },
+    {
+      "code": 6008,
+      "name": "Paused",
+      "msg": "Paused"
+    },
+    {
+      "code": 6009,
+      "name": "Unauthorized",
+      "msg": "Unauthorized"
     }
   ],
   "types": [
@@ -1255,9 +1380,17 @@
             }
           },
           {
+            "name": "paused",
+            "type": "u8"
+          },
+          {
+            "name": "pausable_admin",
+            "type": "pubkey"
+          },
+          {
             "name": "padding",
             "type": {
-              "array": ["u8", 100]
+              "array": ["u8", 67]
             }
           }
         ]
@@ -1365,6 +1498,10 @@
           {
             "name": "native_fee",
             "type": "u64"
+          },
+          {
+            "name": "message",
+            "type": "string"
           }
         ]
       }
@@ -1445,6 +1582,16 @@
   ],
   "constants": [
     {
+      "name": "ALL_PAUSED",
+      "type": "u8",
+      "value": "3"
+    },
+    {
+      "name": "ALL_UNPAUSED",
+      "type": "u8",
+      "value": "0"
+    },
+    {
       "name": "AUTHORITY_SEED",
       "type": "bytes",
       "value": "[97, 117, 116, 104, 111, 114, 105, 116, 121]"
@@ -1453,6 +1600,16 @@
       "name": "CONFIG_SEED",
       "type": "bytes",
       "value": "[99, 111, 110, 102, 105, 103]"
+    },
+    {
+      "name": "FINALIZE_TRANSFER_PAUSED",
+      "type": "u8",
+      "value": "2"
+    },
+    {
+      "name": "INIT_TRANSFER_PAUSED",
+      "type": "u8",
+      "value": "1"
     },
     {
       "name": "MAX_ALLOWED_DECIMALS",

--- a/src/types/solana/bridge_token_factory.ts
+++ b/src/types/solana/bridge_token_factory.ts
@@ -185,7 +185,7 @@ export type BridgeTokenFactory = {
             {
               name: "sequence"
               docs: [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable.",
               ]
@@ -451,7 +451,7 @@ export type BridgeTokenFactory = {
             {
               name: "sequence"
               docs: [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable.",
               ]
@@ -631,7 +631,7 @@ export type BridgeTokenFactory = {
             {
               name: "sequence"
               docs: [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable.",
               ]
@@ -813,7 +813,7 @@ export type BridgeTokenFactory = {
             {
               name: "sequence"
               docs: [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable.",
               ]
@@ -948,7 +948,7 @@ export type BridgeTokenFactory = {
             {
               name: "sequence"
               docs: [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable.",
               ]
@@ -1084,7 +1084,7 @@ export type BridgeTokenFactory = {
         {
           name: "wormholeSequence"
           docs: [
-            "message is posted, so it needs to be an [UncheckedAccount] for the",
+            "message is posted, so it needs to be an [`UncheckedAccount`] for the",
             "[`initialize`](crate::initialize) instruction.",
             "[`wormhole::post_message`] requires this account be mutable.",
           ]
@@ -1138,6 +1138,10 @@ export type BridgeTokenFactory = {
       args: [
         {
           name: "admin"
+          type: "pubkey"
+        },
+        {
+          name: "pausableAdmin"
           type: "pubkey"
         },
         {
@@ -1237,7 +1241,7 @@ export type BridgeTokenFactory = {
             {
               name: "sequence"
               docs: [
-                "message is posted, so it needs to be an [UncheckedAccount] for the",
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
                 "[`initialize`](crate::initialize) instruction.",
                 "[`wormhole::post_message`] requires this account be mutable.",
               ]
@@ -1299,6 +1303,117 @@ export type BridgeTokenFactory = {
       ]
       args: []
     },
+    {
+      name: "pause"
+      discriminator: [211, 22, 221, 251, 74, 121, 193, 47]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: []
+    },
+    {
+      name: "setAdmin"
+      discriminator: [251, 163, 0, 52, 91, 194, 187, 92]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: [
+        {
+          name: "admin"
+          type: "pubkey"
+        },
+      ]
+    },
+    {
+      name: "setPausableAdmin"
+      discriminator: [128, 59, 6, 173, 50, 0, 213, 197]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: [
+        {
+          name: "pausableAdmin"
+          type: "pubkey"
+        },
+      ]
+    },
+    {
+      name: "unpause"
+      discriminator: [169, 144, 4, 38, 10, 141, 188, 255]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: [
+        {
+          name: "paused"
+          type: "u8"
+        },
+      ]
+    },
   ]
   accounts: [
     {
@@ -1351,6 +1466,16 @@ export type BridgeTokenFactory = {
       name: "invalidFee"
       msg: "Invalid fee"
     },
+    {
+      code: 6008
+      name: "paused"
+      msg: "paused"
+    },
+    {
+      code: 6009
+      name: "unauthorized"
+      msg: "unauthorized"
+    },
   ]
   types: [
     {
@@ -1381,9 +1506,17 @@ export type BridgeTokenFactory = {
             }
           },
           {
+            name: "paused"
+            type: "u8"
+          },
+          {
+            name: "pausableAdmin"
+            type: "pubkey"
+          },
+          {
             name: "padding"
             type: {
-              array: ["u8", 100]
+              array: ["u8", 67]
             }
           },
         ]
@@ -1492,6 +1625,10 @@ export type BridgeTokenFactory = {
             name: "nativeFee"
             type: "u64"
           },
+          {
+            name: "message"
+            type: "string"
+          },
         ]
       }
     },
@@ -1571,6 +1708,16 @@ export type BridgeTokenFactory = {
   ]
   constants: [
     {
+      name: "allPaused"
+      type: "u8"
+      value: "3"
+    },
+    {
+      name: "allUnpaused"
+      type: "u8"
+      value: "0"
+    },
+    {
       name: "authoritySeed"
       type: "bytes"
       value: "[97, 117, 116, 104, 111, 114, 105, 116, 121]"
@@ -1579,6 +1726,16 @@ export type BridgeTokenFactory = {
       name: "configSeed"
       type: "bytes"
       value: "[99, 111, 110, 102, 105, 103]"
+    },
+    {
+      name: "finalizeTransferPaused"
+      type: "u8"
+      value: "2"
+    },
+    {
+      name: "initTransferPaused"
+      type: "u8"
+      value: "1"
     },
     {
       name: "maxAllowedDecimals"


### PR DESCRIPTION
This PR contains two main changes:

## 1. Storage Deposit Fee Calculation Fix

Fixed a bug in the storage deposit calculation for NEAR bridge transfers. Previously, the native fee wasn't being included in the storage deposit amount, which could lead to insufficient funds being deposited. The fix ensures that:

- The `neededAmount` calculation now includes the `nativeFee`
- Both wallet selector and standard NEAR client implementations are updated
- Storage deposits are only made when the total needed amount (including native fee) is greater than 0

## 2. Solana Bridge Updates

Updated the Solana bridge implementation with several key changes:

### Contract Changes
- Added support for message fields in transfers
- Introduced pause/unpause functionality with admin controls
- Added a new `pausableAdmin` role for managing pause states
- Added new error types for paused state and unauthorized access

### Configuration Updates
- Updated Wormhole contract address for testnet
- Added new pause-related constants:
  - `ALL_PAUSED` (3)
  - `ALL_UNPAUSED` (0)
  - `INIT_TRANSFER_PAUSED` (1)
  - `FINALIZE_TRANSFER_PAUSED` (2)

### Client Integration
- Updated transfer function calls to include the new message field
- Maintained backward compatibility with existing transfer logic

### Testing & Documentation
The Solana IDL has been updated to reflect all these changes, with improved documentation for account types and instruction parameters.