### PR TITLE
Update VAA handling and type refinements for NEAR bridge client

### DIFF
--- a/.changeset/curvy-dodos-scream.md
+++ b/.changeset/curvy-dodos-scream.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+refactor(near): update VAA encoding and ProofKind types for transfer finalization

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ const transfer = {
 // Initiate on Solana
 const result = await omniTransfer(provider, transfer);
 
-// Get Wormhole VAA
+// Get Wormhole VAA (returns hex-encoded string)
 const vaa = await getVaa(result.txHash, "Testnet");
 
 // Finalize on NEAR
@@ -274,7 +274,9 @@ await nearClient.finalizeTransfer(
   "recipient.near",
   storageDeposit,
   ChainKind.Sol,
-  vaa // Wormhole VAA required for Solana->NEAR
+  vaa, // Wormhole VAA required for Solana->NEAR
+  undefined, // No EVM proof needed
+  ProofKind.InitTransfer
 );
 ```
 
@@ -314,7 +316,8 @@ await nearClient.finalizeTransfer(
   storageDeposit,
   ChainKind.Eth,
   undefined, // No VAA needed
-  proof // EVM proof required
+  proof, // EVM proof required
+  ProofKind.InitTransfer
 );
 ```
 

--- a/src/proofs/wormhole.ts
+++ b/src/proofs/wormhole.ts
@@ -9,5 +9,5 @@ export async function getVaa(txHash: string, network: "Mainnet" | "Testnet" | "D
     throw new Error("No VAA found")
   }
   const serialized = serialize(result)
-  return Buffer.from(serialized).toString("base64")
+  return Buffer.from(serialized).toString("hex")
 }

--- a/src/types/prover.ts
+++ b/src/types/prover.ts
@@ -1,12 +1,18 @@
-import { BorshSchema } from "borsher"
+import { BorshSchema, type Unit } from "borsher"
 import type { AccountId, Fee, Nonce, OmniAddress, U128 } from "./common"
 
-export enum ProofKind {
-  InitTransfer = 0,
-  FinTransfer = 1,
-  DeployToken = 2,
-  LogMetadata = 3,
-}
+export type ProofKind =
+  | { InitTransfer: Unit }
+  | { FinTransfer: Unit }
+  | { DeployToken: Unit }
+  | { LogMetadata: Unit }
+
+export const ProofKind = {
+  InitTransfer: { InitTransfer: {} } as ProofKind,
+  FinTransfer: { FinTransfer: {} } as ProofKind,
+  DeployToken: { DeployToken: {} } as ProofKind,
+  LogMetadata: { LogMetadata: {} } as ProofKind,
+} as const
 
 export const ProofKindSchema = BorshSchema.Enum({
   InitTransfer: BorshSchema.Unit,

--- a/tests/chains/near.test.ts
+++ b/tests/chains/near.test.ts
@@ -255,7 +255,7 @@ describe("NearBridgeClient", () => {
 
       expect(mockWallet.functionCall).toHaveBeenCalledWith({
         contractId: mockLockerAddress,
-        methodName: "finalize_transfer",
+        methodName: "fin_transfer",
         args: expect.any(Uint8Array),
         gas: BigInt(3e14),
         attachedDeposit: BigInt(1),
@@ -275,7 +275,7 @@ describe("NearBridgeClient", () => {
 
       expect(mockWallet.functionCall).toHaveBeenCalledWith({
         contractId: mockLockerAddress,
-        methodName: "finalize_transfer",
+        methodName: "fin_transfer",
         args: expect.any(Uint8Array),
         gas: BigInt(3e14),
         attachedDeposit: BigInt(1),


### PR DESCRIPTION
## Changes
- Changed VAA encoding from base64 to hex string format to match updated locker contract expectations
- Refactored `ProofKind` from a numeric enum to a tagged union type for better type safety and runtime validation
- Enhanced `finalizeTransfer` method:
  - Added optional `proofKind` parameter (defaults to `InitTransfer`)
  - Strengthened type safety by using `AccountId` type for token and account parameters
  - Updated to use renamed contract method `fin_transfer` (previously `finalize_transfer`)

## Testing
Please verify these changes by:
1. Testing VAA finalization with hex-encoded VAAs from testnet
2. Verifying transfers work with both InitTransfer and DeployToken proof kinds
3. Confirming backwards compatibility with existing client implementations

## Additional Notes
- This change is backwards compatible with existing VAA formats as long as they are properly hex-encoded
- The `ProofKind` change provides better type safety but requires updates to any code explicitly referencing the enum values