### PR TITLE
Convert ChainKind from Tagged Union to Enum

### DIFF
--- a/.changeset/few-otters-battle.md
+++ b/.changeset/few-otters-battle.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": minor
+---
+
+refactor(chains): convert ChainKind from tagged union to enum for simpler type system

--- a/src/api.ts
+++ b/src/api.ts
@@ -108,7 +108,6 @@ export class OmniBridgeAPI {
     }
 
     if (!response.ok) {
-      console.log(response)
       throw new ApiError("API request failed", response.status, response.statusText)
     }
 

--- a/src/proofs/evm.ts
+++ b/src/proofs/evm.ts
@@ -3,7 +3,7 @@ import { RLP } from "@ethereumjs/rlp"
 import { MapDB, bigIntToHex } from "@ethereumjs/util"
 import { ethers } from "ethers"
 import type { BlockTag, Log, TransactionReceipt, TransactionReceiptParams } from "ethers"
-import { type ChainTag, ChainUtils, type EVMChainKind } from "../clients/evm"
+import type { EVMChainKind } from "../clients"
 import { ChainKind, type EvmProof } from "../types"
 
 interface BlockHeader {
@@ -29,15 +29,14 @@ interface BlockHeader {
   parentBeaconBlockRoot?: string
 }
 
-const RPC_URLS: Record<ChainTag<EVMChainKind>, string> = {
-  Eth: "https://eth.llamarpc.com",
-  Base: "https://mainnet.base.org",
-  Arb: "https://arb1.arbitrum.io/rpc",
+const RPC_URLS: Record<EVMChainKind, string> = {
+  [ChainKind.Eth]: "https://eth.llamarpc.com",
+  [ChainKind.Base]: "https://mainnet.base.org",
+  [ChainKind.Arb]: "https://arb1.arbitrum.io/rpc",
 }
 
-function getChainRpcUrl(chain: ChainKind): string {
-  const chainTag = ChainUtils.getTag(chain)
-  const url = RPC_URLS[chainTag]
+function getChainRpcUrl(chain: EVMChainKind): string {
+  const url = RPC_URLS[chain]
   if (!url) {
     throw new Error(`No RPC URL configured for chain: ${chain}`)
   }
@@ -61,15 +60,14 @@ class ExtendedProvider extends ethers.JsonRpcProvider {
 export async function getEvmProof(
   txHash: string,
   topic: string,
-  chain: ChainKind = ChainKind.Eth,
+  chain: EVMChainKind = ChainKind.Eth,
 ): Promise<EvmProof> {
-  console.log()
   const rpcUrl = getChainRpcUrl(chain)
 
   const provider = new ExtendedProvider(rpcUrl)
   const receipt = await provider.getTransactionReceipt(txHash)
   if (!receipt) {
-    throw new Error(`Transaction receipt not found on ${ChainUtils.getTag(chain)}`)
+    throw new Error(`Transaction receipt not found on ${ChainKind[chain]}`)
   }
 
   const blockNumber = bigIntToHex(BigInt(receipt.blockNumber))

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -1,25 +1,13 @@
-import type { Unit } from "borsher"
 import { BorshSchema } from "borsher"
 
-export type ChainKind =
-  | { Eth: Unit }
-  | { Near: Unit }
-  | { Sol: Unit }
-  | { Arb: Unit }
-  | { Base: Unit }
+export enum ChainKind {
+  Eth = 0,
+  Near = 1,
+  Sol = 2,
+  Arb = 3,
+  Base = 4,
+}
 
-export const ChainKind = {
-  Eth: { Eth: {} } as ChainKind,
-  Near: { Near: {} } as ChainKind,
-  Sol: { Sol: {} } as ChainKind,
-  Arb: { Arb: {} } as ChainKind,
-  Base: { Base: {} } as ChainKind,
-} as const
-
-export const ChainKindSchema = BorshSchema.Enum({
-  Eth: BorshSchema.Unit,
-  Near: BorshSchema.Unit,
-  Sol: BorshSchema.Unit,
-  Arb: BorshSchema.Unit,
-  Base: BorshSchema.Unit,
-})
+// TypeScript Enums like this serialize to simple numbers in Borsh.
+// This is highly specific to numeric enums, though. It does not apply to much else.
+export const ChainKindSchema = BorshSchema.u8

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,33 +1,25 @@
 import { ChainKind } from "./types"
 import type { OmniAddress } from "./types"
 
+type ChainPrefix = "eth" | "near" | "sol" | "arb" | "base"
+
 // Helper function to construct OmniAddress
 export const omniAddress = (chain: ChainKind, address: string): OmniAddress => {
-  if ("Eth" in chain) return `eth:${address}`
-  if ("Near" in chain) return `near:${address}`
-  if ("Sol" in chain) return `sol:${address}`
-  if ("Arb" in chain) return `arb:${address}`
-  if ("Base" in chain) return `base:${address}`
-  throw new Error("Unknown chain kind")
+  const prefix = ChainKind[chain].toLowerCase() as ChainPrefix
+  return `${prefix}:${address}`
 }
 
-// Get chain from OmniAddress
+// Extract chain from omni address
 export const getChain = (addr: OmniAddress): ChainKind => {
-  const [prefix] = addr.split(":") as [keyof typeof ChainKind]
-  const chain = prefix.toLowerCase()
+  const prefix = addr.split(":")[0] as ChainPrefix
 
-  switch (chain) {
-    case "eth":
-      return ChainKind.Eth
-    case "near":
-      return ChainKind.Near
-    case "sol":
-      return ChainKind.Sol
-    case "arb":
-      return ChainKind.Arb
-    case "base":
-      return ChainKind.Base
-    default:
-      throw new Error(`Unknown chain prefix: ${prefix}`)
-  }
+  const chainMapping = {
+    eth: ChainKind.Eth,
+    near: ChainKind.Near,
+    sol: ChainKind.Sol,
+    arb: ChainKind.Arb,
+    base: ChainKind.Base,
+  } as const
+
+  return chainMapping[prefix]
 }


### PR DESCRIPTION
This PR converts the `ChainKind` type from a tagged union to a TypeScript enum, simplifying our chain type system and making it more maintainable. This change brings several improvements to our codebase.

## Key Changes

- Replaced `ChainKind` tagged union type with a numeric enum
- Removed `ChainUtils` helper class and simplified chain comparison logic
- Updated `BorshSchema` to use a simple `u8` for chain serialization
- Simplified chain prefix handling in utils.ts using direct enum mapping
- Refactored EVM client to use enum values directly in type definitions and gas configurations
- Updated RPC URL mapping to use enum keys

## Benefits

- **Simpler Type System**: Using an enum makes the chain type system more straightforward and easier to understand
- **Better Type Safety**: Direct enum comparisons are more reliable than string-based tag checking
- **Reduced Boilerplate**: Eliminated need for helper functions to extract and compare chain types
- **More Efficient Serialization**: Chain kinds now serialize to simple numbers in Borsh
- **Cleaner Code**: Removed complex type manipulation and helper functions


## Additional Changes

- Removed unnecessary console.log in api.ts
- Fixed import grouping and type imports in various files
- Improved error messages to use enum value names
- Added type safety for chain prefixes


Closes #73 