### PR TITLE
BigInt Parsing Improvements for API Responses

### DIFF
--- a/.changeset/angry-dolls-jump.md
+++ b/.changeset/angry-dolls-jump.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+feat: improve bigint parsing to handle scientific notation and preserve precision

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -41,6 +41,7 @@ const normalizedTransfer = {
   ...mockTransfer,
   transfer_message: {
     ...mockTransfer.transfer_message,
+    amount: BigInt(mockTransfer.transfer_message.amount),
     fee: {
       fee: BigInt(mockTransfer.transfer_message.fee.fee),
       native_fee: BigInt(mockTransfer.transfer_message.fee.native_fee),

--- a/tests/integration/__snapshots__/api.test.ts.snap
+++ b/tests/integration/__snapshots__/api.test.ts.snap
@@ -17,10 +17,10 @@ exports[`OmniBridgeAPI Integration Tests > findOmniTransfers > should fetch tran
       },
     },
     "transfer_message": {
-      "amount": 2000000000000000,
+      "amount": 2000000000000000n,
       "fee": {
-        "fee": "0",
-        "native_fee": "0",
+        "fee": 0n,
+        "native_fee": 0n,
       },
       "msg": "",
       "recipient": "near:amogas.testnet",
@@ -54,10 +54,10 @@ exports[`OmniBridgeAPI Integration Tests > getTransfer > should fetch transfer d
     },
   },
   "transfer_message": {
-    "amount": 1000000000000000,
+    "amount": 1000000000000000n,
     "fee": {
-      "fee": "0",
-      "native_fee": "0",
+      "fee": 0n,
+      "native_fee": 0n,
     },
     "msg": "",
     "recipient": "near:amogas.testnet",

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -61,20 +61,7 @@ describe("OmniBridgeAPI Integration Tests", () => {
   describe("getTransfer", () => {
     it("should fetch transfer details for a known transfer", async () => {
       const transfer = await api.getTransfer("Eth", 53)
-
-      // Need to convert BigInts to strings for snapshot
-      const snapshotSafeTransfer = {
-        ...transfer,
-        transfer_message: {
-          ...transfer.transfer_message,
-          fee: {
-            fee: transfer.transfer_message.fee.fee.toString(),
-            native_fee: transfer.transfer_message.fee.native_fee.toString(),
-          },
-        },
-      }
-
-      expect(snapshotSafeTransfer).toMatchSnapshot()
+      expect(transfer).toMatchSnapshot()
     })
 
     it("should handle non-existent transfer", async () => {
@@ -86,19 +73,7 @@ describe("OmniBridgeAPI Integration Tests", () => {
       const txId = "0x0b08b481f24e9df5fc5988777933796173e1f5ef9aa4878557df0a4f5b7d8ad0"
       const transfers = await api.findOmniTransfers({ transaction_id: txId })
 
-      // Convert BigInts to strings for snapshot
-      const snapshotSafeTransfers = transfers.map((transfer) => ({
-        ...transfer,
-        transfer_message: {
-          ...transfer.transfer_message,
-          fee: {
-            fee: transfer.transfer_message.fee.fee.toString(),
-            native_fee: transfer.transfer_message.fee.native_fee.toString(),
-          },
-        },
-      }))
-
-      expect(snapshotSafeTransfers).toMatchSnapshot()
+      expect(transfers).toMatchSnapshot()
     })
 
     it("should fetch transfers for a specific sender", async () => {
@@ -122,7 +97,7 @@ describe("OmniBridgeAPI Integration Tests", () => {
           finalised: expect.toBeOneOf([expect.anything(), undefined, null]), // null or transaction object
           transfer_message: {
             token: expect.any(String),
-            amount: expect.any(Number),
+            amount: expect.any(BigInt),
             sender: expect.any(String),
             recipient: expect.any(String),
             fee: {


### PR DESCRIPTION
## Problem
Our current BigInt coercion doesn't handle all numeric formats returned by the API, particularly scientific notation (e.g. `1e+24`) and large integer strings. This can lead to parsing errors or precision loss when processing bridge transfer amounts and fees.

## Solution
Added a `safeBigInt` transformer that properly handles:
- Scientific notation (both string "1e24" and number 1e24)
- Large integer strings
- Regular numbers
- Nullable fields