### PR TITLE
fix(api): use correct mainnet API base URL

### DIFF
--- a/.changeset/few-ligers-double.md
+++ b/.changeset/few-ligers-double.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+fix(api): use correct mainnet API base URL with 'mainnet' subdomain

--- a/src/api.ts
+++ b/src/api.ts
@@ -135,7 +135,7 @@ export class OmniBridgeAPI {
   public getDefaultBaseUrl(): string {
     return getNetwork() === "testnet"
       ? "https://testnet.api.bridge.nearone.org"
-      : "https://api.bridge.nearone.org"
+      : "https://mainnet.api.bridge.nearone.org"
   }
 
   private async fetchWithValidation<T extends z.ZodType>(url: URL, schema: T): Promise<z.infer<T>> {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -37,7 +37,7 @@ describe("Config", () => {
 
   it("should set the base URL for OmniBridgeAPI", () => {
     const api = new OmniBridgeAPI()
-    expect(api.getDefaultBaseUrl()).toBe("https://api.bridge.nearone.org")
+    expect(api.getDefaultBaseUrl()).toBe("https://mainnet.api.bridge.nearone.org")
     setNetwork("testnet")
     expect(api.getDefaultBaseUrl()).toBe("https://testnet.api.bridge.nearone.org")
   })


### PR DESCRIPTION
**Changes**  
- Updated mainnet API endpoint from `https://api.bridge.nearone.org` to `https://mainnet.api.bridge.nearone.org`  
- Maintained testnet URL unchanged  
