### PR TITLE
Decimal Normalization for Cross-Chain Transfers

### DIFF
--- a/.changeset/stupid-fans-teach.md
+++ b/.changeset/stupid-fans-teach.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": minor
+---
+
+feat: add decimal normalization checks to prevent dust amounts in cross-chain transfers

--- a/.changeset/violet-seahorses-tap.md
+++ b/.changeset/violet-seahorses-tap.md
@@ -1,5 +1,0 @@
----
-"omni-bridge-sdk": patch
----
-
-feat: support transaction injection in bridge clients

--- a/.changeset/violet-seahorses-tap.md
+++ b/.changeset/violet-seahorses-tap.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+feat: support transaction injection in bridge clients

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,4 +49,7 @@ export const addresses = {
   get sol() {
     return ADDRESSES[selectedNetwork].sol
   },
+  get network() {
+    return selectedNetwork
+  },
 }

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,5 +1,5 @@
-import { ChainKind } from "./types"
-import type { OmniAddress } from "./types"
+import type { OmniAddress } from "../types"
+import { ChainKind } from "../types"
 
 type ChainPrefix = "eth" | "near" | "sol" | "arb" | "base"
 

--- a/src/utils/decimals.ts
+++ b/src/utils/decimals.ts
@@ -1,0 +1,142 @@
+import { addresses } from "../config"
+import type { OmniAddress } from "../types"
+
+export interface TokenDecimals {
+  decimals: number
+  origin_decimals: number
+}
+
+/**
+ * Normalizes an amount from one decimal precision to another using BigInt math
+ * @param amount The amount to normalize as a bigint
+ * @param fromDecimals The source decimal precision
+ * @param toDecimals The target decimal precision
+ * @returns The normalized amount as a bigint
+ */
+export function normalizeAmount(amount: bigint, fromDecimals: number, toDecimals: number): bigint {
+  if (fromDecimals === toDecimals) return amount
+
+  if (fromDecimals > toDecimals) {
+    // Scale down: Divide by power of 10
+    const scale = 10n ** BigInt(fromDecimals - toDecimals)
+    return amount / scale
+    // biome-ignore lint/style/noUselessElse: Adds clarity
+  } else {
+    // Scale up: Multiply by power of 10
+    const scale = 10n ** BigInt(toDecimals - fromDecimals)
+    return amount * scale
+  }
+}
+
+/**
+ * Verifies if a transfer amount will be valid after normalization
+ * @param amount The amount to transfer
+ * @param fee The fee to be deducted
+ * @param originDecimals The decimals of the token on the source chain
+ * @param destinationDecimals The decimals of the token on the destination chain
+ * @returns true if the normalized amount (minus fee) will be greater than 0
+ */
+export function verifyTransferAmount(
+  amount: bigint,
+  fee: bigint,
+  originDecimals: number,
+  destinationDecimals: number,
+): boolean {
+  try {
+    // Use the minimum of origin and destination decimals for normalization
+    const minDecimals = Math.min(originDecimals, destinationDecimals)
+
+    // First normalize amount and fee to the minimum decimals
+    const normalizedAmount = normalizeAmount(amount, originDecimals, minDecimals)
+    const normalizedFee = normalizeAmount(fee, originDecimals, minDecimals)
+
+    // Check if amount minus fee is greater than 0
+    return normalizedAmount > normalizedFee && normalizedAmount - normalizedFee > 0n
+  } catch {
+    // If we hit any math errors, the amount is effectively too small
+    return false
+  }
+}
+
+/**
+ * Get the minimum number of decimals between origin and destination chains
+ * @param contractId The NEAR contract to query
+ * @param sourceToken The source token address
+ * @param destinationToken The destination token address
+ * @returns The minimum number of decimals
+ */
+export async function getMinimumDecimals(
+  contractId: string,
+  sourceToken: OmniAddress,
+  destinationToken: OmniAddress,
+): Promise<number> {
+  const sourceDecimals = await getTokenDecimals(contractId, sourceToken)
+  const destDecimals = await getTokenDecimals(contractId, destinationToken)
+
+  return Math.min(sourceDecimals.decimals, destDecimals.decimals)
+}
+
+/**
+ * Gets token decimals from the NEAR contract
+ * @param contractId The NEAR contract ID to query
+ * @param tokenAddress The Omni token address to check
+ * @returns Promise resolving to the token's decimal information
+ */
+export async function getTokenDecimals(
+  contractId: string,
+  tokenAddress: OmniAddress,
+): Promise<TokenDecimals> {
+  const response = await fetch(`https://rpc.${addresses.network}.near.org`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "dontcare",
+      method: "query",
+      params: {
+        request_type: "call_function",
+        finality: "final",
+        account_id: contractId,
+        method_name: "get_token_decimals",
+        args_base64: Buffer.from(JSON.stringify({ address: tokenAddress })).toString("base64"),
+      },
+    }),
+  })
+
+  const result = await response.json()
+
+  if (result.error) {
+    throw new Error(
+      `Failed to get token decimals: ${result.error.message || JSON.stringify(result.error)}`,
+    )
+  }
+
+  // Parse the result which is returned as an encoded JSON string
+  const decoded = Buffer.from(result.result.result).toString()
+  const decimals = JSON.parse(decoded) as TokenDecimals
+
+  return decimals
+}
+
+/**
+ * Gets the minimum transferable amount for a token pair accounting for decimal normalization
+ * @param originDecimals The decimals of the source token
+ * @param destinationDecimals The decimals of the destination token
+ * @returns The minimum transferable amount as a bigint
+ */
+export function getMinimumTransferableAmount(
+  originDecimals: number,
+  destinationDecimals: number,
+): bigint {
+  // Start with 1 in destination decimal system
+  let minAmount = 1n
+
+  // If origin has more decimals, we need to scale up
+  if (originDecimals > destinationDecimals) {
+    minAmount = minAmount * 10n ** BigInt(originDecimals - destinationDecimals)
+  }
+
+  return minAmount
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./chain"
+export * from "./decimals"

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,0 +1,161 @@
+import { ethers } from "ethers"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { TokenDecimals } from "../src/utils/decimals"
+
+// Mock all the clients and dependencies
+vi.mock("../src/clients/evm", () => ({
+  EvmBridgeClient: vi.fn().mockImplementation(() => ({
+    initTransfer: vi.fn().mockResolvedValue("tx-hash"),
+  })),
+}))
+
+vi.mock("../src/clients/near", () => ({
+  NearBridgeClient: vi.fn(),
+}))
+
+vi.mock("../src/clients/near-wallet-selector", () => ({
+  NearWalletSelectorBridgeClient: vi.fn(),
+}))
+
+vi.mock("../src/clients/solana", () => ({
+  SolanaBridgeClient: vi.fn(),
+}))
+
+// Important: Mock fetch before importing omniTransfer
+global.fetch = vi.fn()
+
+// Import after mocks are set up
+import { omniTransfer } from "../src/client"
+
+function mockNearResponse(decimals: TokenDecimals) {
+  const response = {
+    jsonrpc: "2.0",
+    id: "dontcare",
+    result: {
+      result: Array.from(Buffer.from(JSON.stringify(decimals))),
+    },
+  }
+  return Promise.resolve({
+    json: () => Promise.resolve(response),
+  })
+}
+
+describe("omniTransfer", () => {
+  // Setup mock wallet
+  const mockProvider = new ethers.JsonRpcProvider()
+  const wallet = new ethers.Wallet(
+    "0x0123456789012345678901234567890123456789012345678901234567890123",
+    mockProvider,
+  )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("rejects transfer of 1 yoctoNEAR to Solana", async () => {
+    // Mock token decimal responses
+    // @ts-expect-error mock implementation
+    global.fetch.mockImplementation((_url, options) => {
+      const body = JSON.parse(options.body)
+      if (body.params.args_base64) {
+        const args = JSON.parse(Buffer.from(body.params.args_base64, "base64").toString())
+        if (args.address.startsWith("near:")) {
+          return mockNearResponse({ decimals: 24, origin_decimals: 24 })
+        }
+        if (args.address.startsWith("sol:")) {
+          return mockNearResponse({ decimals: 9, origin_decimals: 9 })
+        }
+      }
+      throw new Error("Unexpected RPC call")
+    })
+
+    await expect(
+      omniTransfer(wallet, {
+        tokenAddress: "near:token.near",
+        amount: 1n, // 1 yoctoNEAR
+        fee: 0n,
+        nativeFee: 0n,
+        recipient: "sol:pubkey",
+      }),
+    ).rejects.toThrow("Transfer amount too small")
+  })
+
+  it("allows valid NEAR to Solana transfer", async () => {
+    // Mock token decimal responses
+    // @ts-expect-error mock implementation
+    global.fetch.mockImplementation((_url, options) => {
+      const body = JSON.parse(options.body)
+      if (body.params.args_base64) {
+        const args = JSON.parse(Buffer.from(body.params.args_base64, "base64").toString())
+        if (args.address.startsWith("near:")) {
+          return mockNearResponse({ decimals: 24, origin_decimals: 24 })
+        }
+        if (args.address.startsWith("sol:")) {
+          return mockNearResponse({ decimals: 9, origin_decimals: 9 })
+        }
+      }
+      throw new Error("Unexpected RPC call")
+    })
+
+    const result = await omniTransfer(wallet, {
+      tokenAddress: "near:token.near",
+      amount: 2000000000000000000000000n, // 2.0 NEAR
+      fee: 1000000000000000000000000n, // 1.0 NEAR fee
+      nativeFee: 0n,
+      recipient: "sol:pubkey",
+    })
+
+    expect(result).toBe("tx-hash")
+  })
+
+  it("rejects transfer where fee equals amount", async () => {
+    // Mock token decimal responses
+    // @ts-expect-error mock implementation
+    global.fetch.mockImplementation((_url, options) => {
+      const body = JSON.parse(options.body)
+      if (body.params.args_base64) {
+        const args = JSON.parse(Buffer.from(body.params.args_base64, "base64").toString())
+        if (args.address.startsWith("eth:")) {
+          return mockNearResponse({ decimals: 18, origin_decimals: 18 })
+        }
+        if (args.address.startsWith("sol:")) {
+          return mockNearResponse({ decimals: 9, origin_decimals: 9 })
+        }
+      }
+      throw new Error("Unexpected RPC call")
+    })
+
+    await expect(
+      omniTransfer(wallet, {
+        tokenAddress: "eth:0x123",
+        amount: 1000000000000000000n, // 1.0 ETH
+        fee: 1000000000000000000n, // 1.0 ETH fee
+        nativeFee: 0n,
+        recipient: "sol:pubkey",
+      }),
+    ).rejects.toThrow("Transfer amount too small")
+  })
+
+  it("handles NEAR RPC errors gracefully", async () => {
+    // Mock RPC error
+    // @ts-expect-error mock implementation
+    global.fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            error: { message: "Contract not found" },
+          }),
+      }),
+    )
+
+    await expect(
+      omniTransfer(wallet, {
+        tokenAddress: "near:token.near",
+        amount: 1000000000000000000000000n,
+        fee: 0n,
+        nativeFee: 0n,
+        recipient: "sol:pubkey",
+      }),
+    ).rejects.toThrow("Failed to get token decimals")
+  })
+})

--- a/tests/integration/__snapshots__/decimals.test.ts.snap
+++ b/tests/integration/__snapshots__/decimals.test.ts.snap
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`getTokenDecimals integration > fetches decimals for JLU token on Solana 1`] = `
+{
+  "decimals": 9,
+  "origin_decimals": 18,
+}
+`;
+
+exports[`getTokenDecimals integration > handles invalid token addresses 1`] = `[TypeError: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined]`;

--- a/tests/integration/decimals.test.ts
+++ b/tests/integration/decimals.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { setNetwork } from "../../src/config"
+import { getTokenDecimals } from "../../src/utils/decimals"
+
+describe("getTokenDecimals integration", () => {
+  setNetwork("testnet")
+
+  it("fetches decimals for JLU token on Solana", async () => {
+    const tokenAddress = "sol:rLFLkpdMZsVLWziDfz5WWqVgVnFbPdKicSNQcj9QVxL"
+    const decimals = await getTokenDecimals("omni-locker.testnet", tokenAddress)
+
+    // Verify response structure (these should not change)
+    expect(decimals).toHaveProperty("decimals")
+    expect(decimals).toHaveProperty("origin_decimals")
+    expect(typeof decimals.decimals).toBe("number")
+    expect(typeof decimals.origin_decimals).toBe("number")
+
+    // Snapshot the actual values
+    expect(decimals).toMatchSnapshot({
+      decimals: 9,
+      origin_decimals: 18,
+    })
+  }, 10000) // Increase timeout for RPC call
+
+  it("handles invalid token addresses", async () => {
+    const invalidAddress = "sol:invalid"
+    await expect(getTokenDecimals("omni-locker.testnet", invalidAddress)).rejects.toMatchSnapshot()
+  })
+})

--- a/tests/utils/chain.test.ts
+++ b/tests/utils/chain.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
-import type { OmniAddress } from "../src/types"
-import { ChainKind } from "../src/types"
-import { getChain, omniAddress } from "../src/utils"
+import type { OmniAddress } from "../../src/types"
+import { ChainKind } from "../../src/types"
+import { getChain, omniAddress } from "../../src/utils"
 describe("Omni Address Utils", () => {
   describe("omniAddress", () => {
     it("should construct valid omni addresses", () => {

--- a/tests/utils/decimals.test.ts
+++ b/tests/utils/decimals.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest"
+import type { TokenDecimals } from "../../src/utils/decimals"
+import {
+  getMinimumTransferableAmount,
+  getTokenDecimals,
+  normalizeAmount,
+  verifyTransferAmount,
+} from "../../src/utils/decimals"
+
+// Mock fetch for NEAR RPC calls
+global.fetch = vi.fn()
+
+function mockNearResponse(decimals: TokenDecimals) {
+  const response = {
+    jsonrpc: "2.0",
+    id: "dontcare",
+    result: {
+      result: Array.from(Buffer.from(JSON.stringify(decimals))),
+    },
+  }
+  return Promise.resolve({
+    json: () => Promise.resolve(response),
+  })
+}
+
+describe("normalizeAmount", () => {
+  it("handles equal decimals", () => {
+    const amount = 1000000n // 1.0 with 6 decimals
+    expect(normalizeAmount(amount, 6, 6)).toBe(1000000n)
+  })
+
+  it("scales down from NEAR (24) to Solana (9)", () => {
+    const amount = 1000000000000000000000000n // 1.0 NEAR
+    const expected = 1000000000n // 1.0 in Solana decimals
+    expect(normalizeAmount(amount, 24, 9)).toBe(expected)
+  })
+
+  it("scales down from ETH (18) to Solana (9)", () => {
+    const amount = 1000000000000000000n // 1.0 ETH
+    const expected = 1000000000n // 1.0 in Solana decimals
+    expect(normalizeAmount(amount, 18, 9)).toBe(expected)
+  })
+
+  it("scales up from Solana (9) to NEAR (24)", () => {
+    const amount = 1000000000n // 1.0 in Solana
+    const expected = 1000000000000000000000000n // 1.0 in NEAR
+    expect(normalizeAmount(amount, 9, 24)).toBe(expected)
+  })
+
+  it("handles edge case of 1 yoctoNEAR to Solana", () => {
+    const amount = 1n // 1 yoctoNEAR
+    expect(normalizeAmount(amount, 24, 9)).toBe(0n)
+  })
+
+  it("maintains precision when possible", () => {
+    // 0.000000000000000001 ETH (smallest unit)
+    const amount = 1n
+    // Should maintain precision when going to 24 decimals
+    const expected = 1000000n
+    expect(normalizeAmount(amount, 18, 24)).toBe(expected)
+  })
+})
+
+describe("verifyTransferAmount", () => {
+  it("approves valid NEAR to Solana transfer", () => {
+    const amount = 2000000000000000000000000n // 2.0 NEAR
+    const fee = 1000000000000000000000000n // 1.0 NEAR fee
+    expect(verifyTransferAmount(amount, fee, 24, 9)).toBe(true)
+  })
+
+  it("rejects transfer that would normalize to zero", () => {
+    const amount = 1n // 1 yoctoNEAR
+    const fee = 0n
+    expect(verifyTransferAmount(amount, fee, 24, 9)).toBe(false)
+  })
+
+  it("rejects transfer where fee equals amount", () => {
+    const amount = 1000000000000000000000000n // 1.0 NEAR
+    const fee = 1000000000000000000000000n // 1.0 NEAR
+    expect(verifyTransferAmount(amount, fee, 24, 9)).toBe(false)
+  })
+
+  it("approves valid ETH to Solana transfer", () => {
+    const amount = 2000000000000000000n // 2.0 ETH
+    const fee = 1000000000000000000n // 1.0 ETH fee
+    expect(verifyTransferAmount(amount, fee, 18, 9)).toBe(true)
+  })
+
+  it("handles transfers to higher precision", () => {
+    const amount = 2000000000n // 2.0 SOL
+    const fee = 1000000000n // 1.0 SOL fee
+    expect(verifyTransferAmount(amount, fee, 9, 18)).toBe(true)
+  })
+})
+
+describe("getMinimumTransferableAmount", () => {
+  it("calculates minimum for NEAR to Solana", () => {
+    const minAmount = getMinimumTransferableAmount(24, 9)
+    // 1 SOL unit worth of NEAR (scaled up to 24 decimals)
+    expect(minAmount).toBe(1000000000000000n)
+  })
+
+  it("calculates minimum for ETH to Solana", () => {
+    const minAmount = getMinimumTransferableAmount(18, 9)
+    // 1 SOL unit worth of ETH (scaled up to 18 decimals)
+    expect(minAmount).toBe(1000000000n)
+  })
+
+  it("calculates minimum for Solana to NEAR", () => {
+    const minAmount = getMinimumTransferableAmount(9, 24)
+    // 1 lamport (smallest Solana unit)
+    expect(minAmount).toBe(1n)
+  })
+
+  it("handles equal decimals", () => {
+    const minAmount = getMinimumTransferableAmount(6, 6)
+    expect(minAmount).toBe(1n)
+  })
+})
+
+describe("getTokenDecimals", () => {
+  it("fetches token decimals from NEAR contract", async () => {
+    const mockDecimals: TokenDecimals = {
+      decimals: 24,
+      origin_decimals: 18,
+    }
+
+    // @ts-expect-error mock implementation
+    global.fetch.mockImplementationOnce(() => mockNearResponse(mockDecimals))
+
+    const result = await getTokenDecimals("contract.near", "eth:0x123...")
+
+    expect(result).toEqual(mockDecimals)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("handles RPC errors", async () => {
+    // @ts-expect-error mock implementation
+    global.fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            error: { message: "Contract not found" },
+          }),
+      }),
+    )
+
+    await expect(getTokenDecimals("contract.near", "eth:0x123...")).rejects.toThrow(
+      "Failed to get token decimals",
+    )
+  })
+})


### PR DESCRIPTION
# Decimal Normalization for Cross-Chain Transfers

This PR adds decimal normalization validation to prevent "dust" transfers - small amounts that would round to zero when transferred between chains with different decimal precision systems.

## Problem

When transferring tokens between chains with different decimal systems (e.g., NEAR's 24 decimals to Solana's 9 decimals), very small amounts can effectively disappear. For example:
- 1 yoctoNEAR ($1^{-24}$ NEAR) would normalize to 0 when transferred to Solana (9 decimals)
- This leads to failed transfers and locked funds

## Solution

Added pre-flight checks in `omniTransfer()` that:
1. Query token decimals from NEAR contract
2. Verify transfer amount will remain > 0 after normalization
3. Reject transfers that would result in dust amounts
4. Provide helpful error messages with minimum transferable amounts

### Implementation Details

- Added `normalizeAmount()` utility that handles decimal scaling using BigInt math
- Added `verifyTransferAmount()` to check if amount - fee will be valid after normalization
- Added integration tests with snapshots to verify token decimal queries
- Used BigInt throughout to avoid floating point precision issues

### Key Files Changed
- `src/utils/decimals.ts` - Core decimal normalization utilities
- `src/client.ts` - Added pre-flight checks to `omniTransfer()`
- `tests/decimal-utils.integration.test.ts` - Integration tests with snapshots
- `tests/client.test.ts` - Unit tests for transfer validation

### Example

```typescript
// This transfer would be rejected:
await omniTransfer(wallet, {
  tokenAddress: "near:token.near",
  amount: 1n, // 1 yoctoNEAR
  fee: 0n,
  nativeFee: 0n,
  recipient: "sol:pubkey" // Solana has 9 decimals
})
// Error: Transfer amount too small - would result in 0 after decimal normalization

// This transfer would succeed:
await omniTransfer(wallet, {
  tokenAddress: "near:token.near",
  amount: 2000000000000000000000000n, // 2.0 NEAR
  fee: 1000000000000000000000000n,    // 1.0 NEAR fee
  nativeFee: 0n,
  recipient: "sol:pubkey"
})
```

### Testing Strategy

1. **Unit Tests**: 
   - Decimal normalization math
   - Transfer amount validation
   - Different chain combinations
   - Edge cases (e.g., 1 yoctoNEAR)

2. **Integration Tests**:
   - Snapshot tests for NEAR RPC responses
   - Real token decimal queries
   - Error handling

### Decimal Systems by Chain
- NEAR: 24 decimals (yoctoNEAR)
- Ethereum/Base/Arbitrum: 18 decimals (wei)
- Solana: 9 decimals (lamports)

## Future Work
- Add more detailed error messages about minimum amounts
- Cache token decimal information
- Add decimal verification to other bridge operations

## Security Considerations
- Uses BigInt math to avoid floating point precision issues
- Validates both amount and fee normalization
- Handles chain-specific decimal systems correctly

## Dependencies
- No new dependencies added
- Removed reliance on ethers.js FixedNumber in favor of BigInt math