### PR TITLE
fix(test): resolve @near-js/client to CJS to fix ESM import error

### DIFF
--- a/.changeset/spicy-fireants-hammer.md
+++ b/.changeset/spicy-fireants-hammer.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+Fix: Resolve `@near-js/client` to CJS in Vitest config to fix ESM import errors during testing. This prevents test failures caused by a broken ESM build in the `@near-js/client` library.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@near-js/client": require.resolve("@near-js/client"), // Fixes ESM import issues
+    },
+  },
   test: {
     testTimeout: 60_000,
     hookTimeout: 60_000,
-    deps: {
-      inline: [
-        /@near-js\/.*/, // This will match all @near-js packages
-      ],
-    },
   },
 })


### PR DESCRIPTION
Fixes a test failure caused by a broken ESM build of the `@near-js/client` package.

Previously, tests using `@near-js/client` would fail with the following error:

```
Error: Cannot find module '.../node_modules/@near-js/client/lib/esm/constants' imported from .../node_modules/@near-js/client/lib/esm/index.js
```

This indicated a problem with the package's ESM module resolution.  My first attempt to fix this involved using `deps.inline` in the Vitest configuration. However, this didn't work, and I realized it was also too broad, potentially affecting other dependencies unnecessarily. Also, `deps.inline` was deprecated.

This PR resolves the issue by adding an alias in `vitest.config.ts`.  We're now explicitly resolving `@near-js/client` to its CommonJS (CJS) build using `require.resolve`. This bypasses the problematic ESM build, and the tests can now successfully import and use the library.  Also, this is a more targeted and reliable solution compared to inlining dependencies.
