### PR TITLE
Improve Token Resolution and Error Handling

### DIFF
--- a/.changeset/full-heads-relate.md
+++ b/.changeset/full-heads-relate.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+feat(token): Improve token resolution, helpful error messages

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,7 @@ import { NearWalletSelectorBridgeClient } from "./clients/near-wallet-selector"
 import { SolanaBridgeClient } from "./clients/solana"
 import { addresses } from "./config"
 import { ChainKind, type InitTransferEvent, type OmniTransferMessage } from "./types"
-import { getChain, getTokenAddress } from "./utils"
+import { getBridgedToken, getChain } from "./utils"
 import {
   getMinimumTransferableAmount,
   getTokenDecimals,
@@ -52,7 +52,14 @@ export async function omniTransfer(
   const destChain = getChain(transfer.recipient)
 
   const sourceTokenAddress = transfer.tokenAddress
-  const destTokenAddress = await getTokenAddress(transfer.tokenAddress, destChain)
+  const destTokenAddress = await getBridgedToken(transfer.tokenAddress, destChain)
+
+  // Check if destination token address is null
+  if (!destTokenAddress) {
+    throw new Error(
+      `Token ${transfer.tokenAddress} is not registered on the destination chain. Please deploy the token first.`,
+    )
+  }
 
   // Get token decimals
   const contractId = addresses.near // Use NEAR contract for decimal verification

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,45 +1,6 @@
 import { getProviderByNetwork, view } from "@near-js/client"
 import { addresses } from "../config"
 import { ChainKind, type OmniAddress } from "../types"
-import { getChain } from "./chain"
-
-/**
- * Converts a NEAR token to its equivalent on another chain
- * @param tokenAddress The NEAR token address to convert
- * @param destinationChain The target chain for conversion
- * @returns Promise resolving to the equivalent token address on the destination chain
- */
-export async function convertFromNear(
-  tokenAddress: OmniAddress,
-  destinationChain: ChainKind,
-): Promise<OmniAddress> {
-  const rpcProvider = getProviderByNetwork(addresses.network)
-  return await view<OmniAddress>({
-    account: addresses.near,
-    method: "get_token_address",
-    args: {
-      chain_kind: ChainKind[destinationChain],
-      token: tokenAddress.split(":")[1],
-    },
-    deps: { rpcProvider },
-  })
-}
-
-/**
- * Converts a token from another chain to its NEAR equivalent
- * @param tokenAddress The non-NEAR token address to convert
- * @returns Promise resolving to the equivalent NEAR token address
- */
-export async function convertToNear(tokenAddress: OmniAddress): Promise<OmniAddress> {
-  const rpcProvider = getProviderByNetwork(addresses.network)
-  const address = await view<string>({
-    account: addresses.near,
-    method: "get_token_id",
-    args: { address: tokenAddress },
-    deps: { rpcProvider },
-  })
-  return `near:${address}`
-}
 
 /**
  * Converts a token address from one chain to its equivalent on another chain.
@@ -52,33 +13,24 @@ export async function convertToNear(tokenAddress: OmniAddress): Promise<OmniAddr
  *
  * @example
  * // Convert NEAR token to ETH
- * const ethAddress = await getTokenAddress("near:token123", ChainKind.Ethereum)
+ * const ethAddress = await getBridgedToken("near:token123", ChainKind.Ethereum)
  *
  * // Convert ETH token to Solana (goes through NEAR)
- * const solAddress = await getTokenAddress("eth:0x123...", ChainKind.Sol)
+ * const solAddress = await getBridgedToken("eth:0x123...", ChainKind.Sol)
  */
-export async function getTokenAddress(
+export async function getBridgedToken(
   tokenAddress: OmniAddress,
   destinationChain: ChainKind,
-): Promise<OmniAddress> {
-  const sourceChain = getChain(tokenAddress)
-
-  // Validate chains are different
-  if (sourceChain === destinationChain) {
-    throw new Error("Source and destination chains must be different")
-  }
-
-  // Direct NEAR to other chain conversion
-  if (sourceChain === ChainKind.Near) {
-    return convertFromNear(tokenAddress, destinationChain)
-  }
-
-  // Direct other chain to NEAR conversion
-  if (destinationChain === ChainKind.Near) {
-    return convertToNear(tokenAddress)
-  }
-
-  // Non-NEAR to non-NEAR conversion (via NEAR as intermediary)
-  const nearToken = await convertToNear(tokenAddress)
-  return convertFromNear(nearToken, destinationChain)
+): Promise<OmniAddress | null> {
+  const rpcProvider = getProviderByNetwork(addresses.network)
+  console.log(ChainKind[destinationChain].toString())
+  return await view<OmniAddress>({
+    account: addresses.near,
+    method: "get_bridged_token",
+    args: {
+      chain: ChainKind[destinationChain].toString(),
+      address: tokenAddress,
+    },
+    deps: { rpcProvider },
+  })
 }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -23,7 +23,6 @@ export async function getBridgedToken(
   destinationChain: ChainKind,
 ): Promise<OmniAddress | null> {
   const rpcProvider = getProviderByNetwork(addresses.network)
-  console.log(ChainKind[destinationChain].toString())
   return await view<OmniAddress>({
     account: addresses.near,
     method: "get_bridged_token",

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -2,7 +2,7 @@ import { ethers } from "ethers"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type * as decimalsModule from "../src/utils/decimals" // Import for selective mocking
 import { getTokenDecimals } from "../src/utils/decimals"
-import { getTokenAddress } from "../src/utils/tokens" // Import getTokenAddress
+import { getBridgedToken } from "../src/utils/tokens" // Import getBridgedToken
 
 // Mock getTokenDecimals *before* importing client.ts, using importActual
 vi.mock("../src/utils/decimals", async () => {
@@ -13,9 +13,9 @@ vi.mock("../src/utils/decimals", async () => {
   }
 })
 
-// Mock getTokenAddress
+// Mock getBridgedToken
 vi.mock("../src/utils/tokens", () => ({
-  getTokenAddress: vi.fn(),
+  getBridgedToken: vi.fn(),
 }))
 
 // Mock all the clients and dependencies
@@ -69,8 +69,8 @@ describe("omniTransfer", () => {
   })
 
   it("rejects transfer of 1 yoctoNEAR to Solana", async () => {
-    // Mock getTokenAddress
-    vi.mocked(getTokenAddress).mockResolvedValue("sol:mocked_sol_address")
+    // Mock getBridgedToken
+    vi.mocked(getBridgedToken).mockResolvedValue("sol:mocked_sol_address")
 
     await expect(
       omniTransfer(wallet, {
@@ -84,8 +84,8 @@ describe("omniTransfer", () => {
   })
 
   it("allows valid NEAR to Solana transfer", async () => {
-    // Mock getTokenAddress to return a Solana address
-    vi.mocked(getTokenAddress).mockResolvedValue("sol:mocked_sol_address")
+    // Mock getBridgedToken to return a Solana address
+    vi.mocked(getBridgedToken).mockResolvedValue("sol:mocked_sol_address")
 
     const result = await omniTransfer(wallet, {
       tokenAddress: "near:token.near",
@@ -99,8 +99,8 @@ describe("omniTransfer", () => {
   })
 
   it("rejects transfer where fee equals amount", async () => {
-    // Mock getTokenAddress
-    vi.mocked(getTokenAddress).mockResolvedValue("sol:mocked_sol_address")
+    // Mock getBridgedToken
+    vi.mocked(getBridgedToken).mockResolvedValue("sol:mocked_sol_address")
 
     await expect(
       omniTransfer(wallet, {
@@ -117,8 +117,8 @@ describe("omniTransfer", () => {
     // Mock RPC error using mockRejectedValueOnce
     vi.mocked(getTokenDecimals).mockRejectedValueOnce(new Error("Failed to get token decimals"))
 
-    // Mock getTokenAddress
-    vi.mocked(getTokenAddress).mockResolvedValue("sol:mocked_sol_address")
+    // Mock getBridgedToken
+    vi.mocked(getBridgedToken).mockResolvedValue("sol:mocked_sol_address")
 
     await expect(
       omniTransfer(wallet, {
@@ -131,9 +131,9 @@ describe("omniTransfer", () => {
     ).rejects.toThrow("Failed to get token decimals")
   })
 
-  it("handles getTokenAddress errors gracefully", async () => {
+  it("handles getBridgedToken errors gracefully", async () => {
     // Mock RPC error using mockRejectedValueOnce
-    vi.mocked(getTokenAddress).mockRejectedValueOnce(new Error("Failed to get token address"))
+    vi.mocked(getBridgedToken).mockRejectedValueOnce(new Error("Failed to get token address"))
 
     await expect(
       omniTransfer(wallet, {

--- a/tests/integration/tokens.test.ts
+++ b/tests/integration/tokens.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, it, vi } from "vitest"
 import { setNetwork } from "../../src"
 import { ChainKind } from "../../src/types"
-import { getTokenAddress } from "../../src/utils/tokens"
+import { getBridgedToken } from "../../src/utils/tokens"
 
 describe.concurrent("Token Conversion Integration Tests", () => {
   beforeAll(() => {
@@ -11,17 +11,17 @@ describe.concurrent("Token Conversion Integration Tests", () => {
     const nearToken = "near:wrap.testnet"
 
     it("converts NEAR to Solana", async ({ expect }) => {
-      const result = await getTokenAddress(nearToken, ChainKind.Sol)
+      const result = await getBridgedToken(nearToken, ChainKind.Sol)
       expect(result).toMatchInlineSnapshot(`"sol:3wQct2e43J1Z99h2RWrhPAhf6E32ZpuzEt6tgwfEAKAy"`)
     })
 
     it("converts NEAR to Base", async ({ expect }) => {
-      const result = await getTokenAddress(nearToken, ChainKind.Base)
+      const result = await getBridgedToken(nearToken, ChainKind.Base)
       expect(result).toMatchInlineSnapshot(`"base:0xb8cae3ea035ab123c1833258835ef270c9934162"`)
     })
 
     it("converts NEAR to Arbitrum", async ({ expect }) => {
-      const result = await getTokenAddress(nearToken, ChainKind.Arb)
+      const result = await getBridgedToken(nearToken, ChainKind.Arb)
       expect(result).toMatchInlineSnapshot(`"arb:0xf66f061ac678378c949bdfd3cb8c974272db3f59"`)
     })
   })
@@ -30,7 +30,7 @@ describe.concurrent("Token Conversion Integration Tests", () => {
     const nearExpected = "near:wrap.testnet"
 
     it("converts Solana to NEAR", async ({ expect }) => {
-      const result = await getTokenAddress(
+      const result = await getBridgedToken(
         "sol:3wQct2e43J1Z99h2RWrhPAhf6E32ZpuzEt6tgwfEAKAy",
         ChainKind.Near,
       )
@@ -38,7 +38,7 @@ describe.concurrent("Token Conversion Integration Tests", () => {
     })
 
     it("converts Base to NEAR", async ({ expect }) => {
-      const result = await getTokenAddress(
+      const result = await getBridgedToken(
         "base:0xb8cae3ea035ab123c1833258835ef270c9934162",
         ChainKind.Near,
       )
@@ -46,7 +46,7 @@ describe.concurrent("Token Conversion Integration Tests", () => {
     })
 
     it("converts Arbitrum to NEAR", async ({ expect }) => {
-      const result = await getTokenAddress(
+      const result = await getBridgedToken(
         "arb:0xf66f061ac678378c949bdfd3cb8c974272db3f59",
         ChainKind.Near,
       )
@@ -56,7 +56,7 @@ describe.concurrent("Token Conversion Integration Tests", () => {
 
   describe("Cross-chain conversions", () => {
     it("converts Base to Arbitrum", async ({ expect }) => {
-      const result = await getTokenAddress(
+      const result = await getBridgedToken(
         "base:0xb8cae3ea035ab123c1833258835ef270c9934162",
         ChainKind.Arb,
       )
@@ -64,7 +64,7 @@ describe.concurrent("Token Conversion Integration Tests", () => {
     })
 
     it("converts Solana to Base", async ({ expect }) => {
-      const result = await getTokenAddress(
+      const result = await getBridgedToken(
         "sol:3wQct2e43J1Z99h2RWrhPAhf6E32ZpuzEt6tgwfEAKAy",
         ChainKind.Base,
       )
@@ -80,20 +80,14 @@ describe.concurrent("Token Conversion Integration Tests", () => {
       vi.restoreAllMocks()
     })
 
-    it("throws error when source and destination chains are the same", async ({ expect }) => {
-      await expect(getTokenAddress("near:wrap.testnet", ChainKind.Near)).rejects.toThrow(
-        "Source and destination chains must be different",
-      )
-    })
-
     it("throws error for invalid token address format", async ({ expect }) => {
-      await expect(getTokenAddress("sol:address", ChainKind.Eth)).rejects.toThrow()
+      await expect(getBridgedToken("sol:address", ChainKind.Eth)).rejects.toThrow()
     })
 
     it("throws error for unknown token address", async ({ expect }) => {
       await expect(
-        getTokenAddress("eth:0x1234567890123456789012345678901234567890", ChainKind.Near),
-      ).rejects.toThrow()
+        getBridgedToken("eth:0x1234567890123456789012345678901234567890", ChainKind.Near),
+      ).resolves.toBeNull()
     })
   })
 })

--- a/tests/utils/tokens.test.ts
+++ b/tests/utils/tokens.test.ts
@@ -1,22 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { getChain } from "../../src"
 import { ChainKind, type OmniAddress } from "../../src/types"
+import { getBridgedToken } from "../../src/utils"
 
-// First mock @near-js/client
+// Mock @near-js/client
 vi.mock("@near-js/client", () => ({
   getProviderByNetwork: vi.fn(),
   view: vi.fn(),
 }))
 
-// Import the actual functions
+// Import the mocked function
+import { view } from "@near-js/client"
 
-// Define types for our token mapping
+// Define token mapping with proper types
 type ChainMapping = {
-  [K in ChainKind]?: string
+  [key in ChainKind]?: OmniAddress
 }
 
 type TokenMapping = {
-  [key: string]: ChainMapping
+  [address: string]: ChainMapping
 }
 
 // Define token mapping as source of truth
@@ -28,169 +29,81 @@ const TOKEN_MAPPING: TokenMapping = {
     [ChainKind.Base]: "base:0xf66f061ac678378c949bdfd3cb8c974272db3f59",
     [ChainKind.Arb]: "arb:0x02eea354d135d1a912967c2d2a6147deb01ef92e",
   },
-  // Other chains to NEAR
+  // Other chains to their mapped tokens
   "eth:0xa2e932310e7294451d8417aa9b2e647e67df3288": {
-    [ChainKind.Near]: "wrap.testnet",
+    [ChainKind.Near]: "near:wrap.testnet",
+    [ChainKind.Sol]: "sol:FUfkKBMpZ74vdWmPjjLpmuekqVkBMjbHqHedVGdSv929",
+    [ChainKind.Base]: "base:0xf66f061ac678378c949bdfd3cb8c974272db3f59",
+    [ChainKind.Arb]: "arb:0x02eea354d135d1a912967c2d2a6147deb01ef92e",
   },
   "sol:FUfkKBMpZ74vdWmPjjLpmuekqVkBMjbHqHedVGdSv929": {
-    [ChainKind.Near]: "wrap.testnet",
-  },
-  "base:0xf66f061ac678378c949bdfd3cb8c974272db3f59": {
-    [ChainKind.Near]: "wrap.testnet",
-  },
-  "arb:0x02eea354d135d1a912967c2d2a6147deb01ef92e": {
-    [ChainKind.Near]: "wrap.testnet",
+    [ChainKind.Near]: "near:wrap.testnet",
+    [ChainKind.Eth]: "eth:0xa2e932310e7294451d8417aa9b2e647e67df3288",
   },
 }
 
-// Create mock functions
-const mockConvertToNear = vi.fn()
-const mockConvertFromNear = vi.fn()
-
-describe("Token Conversion", () => {
+describe("Token Resolution", () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    // Setup our mock implementations
-    mockConvertToNear.mockImplementation(async (tokenAddress: OmniAddress) => {
-      const mapping = TOKEN_MAPPING[tokenAddress]
-      if (!mapping?.[ChainKind.Near]) {
-        throw new Error("Invalid token address")
-      }
-      return `near:${mapping[ChainKind.Near]}`
-    })
+    // Mock the view function to simulate contract responses using proper vitest syntax
+    const mockView = vi.mocked(view)
 
-    mockConvertFromNear.mockImplementation(
-      async (tokenAddress: OmniAddress, destinationChain: ChainKind) => {
-        const mapping = TOKEN_MAPPING[tokenAddress]
-        if (!mapping?.[destinationChain]) {
-          throw new Error("Conversion failed")
-        }
-        return mapping[destinationChain]
-      },
-    )
+    // @ts-ignore mock params
+    mockView.mockImplementation(async (params: unknown) => {
+      const chain = (params as { args: { chain: string } }).args?.chain
+      const address = (params as { args: { address: string } }).args?.address
+
+      if (!chain || !address) return null
+
+      // Convert string enum name to enum value
+      const chainEnum = ChainKind[chain as keyof typeof ChainKind]
+
+      if (!TOKEN_MAPPING[address] || !TOKEN_MAPPING[address][chainEnum]) {
+        return null
+      }
+      return TOKEN_MAPPING[address][chainEnum]
+    })
   })
 
-  // Helper function for testing that uses dependency injection
-  const testGetTokenAddress = async (tokenAddress: OmniAddress, destinationChain: ChainKind) => {
-    // First validate chains are different
-    const sourceChain = getChain(tokenAddress)
-
-    if (sourceChain === destinationChain) {
-      throw new Error("Source and destination chains must be different")
-    }
-
-    if (sourceChain === ChainKind.Near) {
-      return mockConvertFromNear(tokenAddress, destinationChain)
-    }
-
-    if (destinationChain === ChainKind.Near) {
-      return mockConvertToNear(tokenAddress)
-    }
-
-    const nearToken = await mockConvertToNear(tokenAddress)
-    return mockConvertFromNear(nearToken, destinationChain)
-  }
-
-  describe("Direct Conversions", () => {
-    it("throws error when source and destination chains are the same", async () => {
-      await expect(testGetTokenAddress("near:wrap.testnet", ChainKind.Near)).rejects.toThrow(
-        "Source and destination chains must be different",
+  describe("getBridgedToken", () => {
+    it("resolves a token from NEAR to ETH", async () => {
+      const result = await getBridgedToken("near:wrap.testnet", ChainKind.Eth)
+      expect(result).toBe("eth:0xa2e932310e7294451d8417aa9b2e647e67df3288")
+      expect(view).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "get_bridged_token",
+          args: {
+            chain: "Eth",
+            address: "near:wrap.testnet",
+          },
+        }),
       )
     })
 
-    it("converts from NEAR to ETH directly", async () => {
-      const result = await testGetTokenAddress("near:wrap.testnet", ChainKind.Eth)
-      expect(result).toBe(TOKEN_MAPPING["near:wrap.testnet"][ChainKind.Eth])
-      expect(mockConvertFromNear).toHaveBeenCalledWith("near:wrap.testnet", ChainKind.Eth)
-      expect(mockConvertToNear).not.toHaveBeenCalled()
-    })
-
-    it("converts from ETH to NEAR directly", async () => {
+    it("resolves a token from ETH to NEAR", async () => {
       const ethAddress = "eth:0xa2e932310e7294451d8417aa9b2e647e67df3288"
-      const result = await testGetTokenAddress(ethAddress, ChainKind.Near)
+      const result = await getBridgedToken(ethAddress, ChainKind.Near)
       expect(result).toBe("near:wrap.testnet")
-      expect(mockConvertToNear).toHaveBeenCalledWith(ethAddress)
-      expect(mockConvertFromNear).not.toHaveBeenCalled()
     })
-  })
 
-  describe("Cross-chain Conversions", () => {
-    it("converts from ETH to SOL via NEAR as intermediary", async () => {
+    it("resolves a token from ETH to SOL directly", async () => {
       const ethAddress = "eth:0xa2e932310e7294451d8417aa9b2e647e67df3288"
-      const result = await testGetTokenAddress(ethAddress, ChainKind.Sol)
-      expect(result).toBe(TOKEN_MAPPING["near:wrap.testnet"][ChainKind.Sol])
-      expect(mockConvertToNear).toHaveBeenCalledWith(ethAddress)
-      expect(mockConvertFromNear).toHaveBeenCalledWith("near:wrap.testnet", ChainKind.Sol)
+      const result = await getBridgedToken(ethAddress, ChainKind.Sol)
+      expect(result).toBe("sol:FUfkKBMpZ74vdWmPjjLpmuekqVkBMjbHqHedVGdSv929")
     })
 
-    it("converts from BASE to ARB via NEAR as intermediary", async () => {
-      const baseAddress = "base:0xf66f061ac678378c949bdfd3cb8c974272db3f59"
-      const result = await testGetTokenAddress(baseAddress, ChainKind.Arb)
-      expect(result).toBe(TOKEN_MAPPING["near:wrap.testnet"][ChainKind.Arb])
-      expect(mockConvertToNear).toHaveBeenCalledWith(baseAddress)
-      expect(mockConvertFromNear).toHaveBeenCalledWith("near:wrap.testnet", ChainKind.Arb)
-    })
-  })
-
-  describe("Comprehensive Tests", () => {
-    it("converts all possible NEAR combinations", async () => {
-      const nearToken = "near:wrap.testnet"
-      const destinations = [ChainKind.Eth, ChainKind.Sol, ChainKind.Base, ChainKind.Arb]
-
-      for (const destChain of destinations) {
-        const result = await testGetTokenAddress(nearToken, destChain)
-        expect(result).toBe(TOKEN_MAPPING[nearToken][destChain])
-        expect(mockConvertFromNear).toHaveBeenCalledWith(nearToken, destChain)
-      }
+    it("returns null for unregistered tokens", async () => {
+      const invalidAddress = "sol:unregistered"
+      const result = await getBridgedToken(invalidAddress, ChainKind.Eth)
+      expect(result).toBeNull()
     })
 
-    it("converts all chains to NEAR", async () => {
-      const sourceAddresses: OmniAddress[] = [
-        "eth:0xa2e932310e7294451d8417aa9b2e647e67df3288",
-        "sol:FUfkKBMpZ74vdWmPjjLpmuekqVkBMjbHqHedVGdSv929",
-        "base:0xf66f061ac678378c949bdfd3cb8c974272db3f59",
-        "arb:0x02eea354d135d1a912967c2d2a6147deb01ef92e",
-      ]
-
-      for (const address of sourceAddresses) {
-        const result = await testGetTokenAddress(address, ChainKind.Near)
-        expect(result).toBe("near:wrap.testnet")
-        expect(mockConvertToNear).toHaveBeenCalledWith(address)
-      }
-    })
-  })
-
-  describe("Error Cases", () => {
-    it("handles invalid token address", async () => {
-      const invalidAddress = "sol:address"
-      await expect(testGetTokenAddress(invalidAddress, ChainKind.Eth)).rejects.toThrow(
-        "Invalid token address",
-      )
-    })
-
-    it("handles conversion to unsupported chain", async () => {
-      const ethAddress = "eth:0xa2e932310e7294451d8417aa9b2e647e67df3288"
-      await expect(testGetTokenAddress(ethAddress, 999 as ChainKind)).rejects.toThrow(
-        "Conversion failed",
-      )
-    })
-
-    it("handles non-existent token mappings", async () => {
-      const invalidNearToken = "near:invalid.testnet"
-      await expect(testGetTokenAddress(invalidNearToken, ChainKind.Eth)).rejects.toThrow(
-        "Conversion failed",
-      )
-    })
-
-    it("handles failure in multi-step conversion", async () => {
-      // Mock success for first step but failure for second step
-      const ethAddress = "eth:0xa2e932310e7294451d8417aa9b2e647e67df3288"
-      mockConvertFromNear.mockRejectedValueOnce(new Error("Destination chain unavailable"))
-
-      await expect(testGetTokenAddress(ethAddress, ChainKind.Sol)).rejects.toThrow(
-        "Destination chain unavailable",
-      )
+    it("returns null for valid tokens with no mapping to the destination chain", async () => {
+      // SOL token has no direct mapping to BASE
+      const solToken = "sol:FUfkKBMpZ74vdWmPjjLpmuekqVkBMjbHqHedVGdSv929"
+      const result = await getBridgedToken(solToken, ChainKind.Base)
+      expect(result).toBeNull()
     })
   })
 })


### PR DESCRIPTION
This PR enhances the token resolution process and adds clearer error messaging for cases where tokens aren't registered on destination chains.

## Changes

- Replaced `getTokenAddress` with a new `getBridgedToken` function that directly calls the contract's `get_bridged_token` method
- Removed complex chain conversion logic (direct NEAR-to-chain, chain-to-NEAR, and chain-to-chain via NEAR as intermediary)
- Added explicit error handling when a destination token address is null, providing a helpful message that guides users to deploy the token first
- Updated function documentation to reflect new naming and behavior

## Impact

Users will now receive a clear error message when attempting to transfer tokens that aren't registered on the destination chain, rather than encountering a confusing runtime error later in the process.

The token resolution process is also simplified, making the code more maintainable and reducing potential points of failure.