### PR TITLE
fix: CI release

### DIFF
--- a/.changeset/heavy-cows-start.md
+++ b/.changeset/heavy-cows-start.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+fix: CI release

--- a/package.json
+++ b/package.json
@@ -55,6 +55,5 @@
     "msw": "^2.7.3",
     "typescript": "^5.8.2",
     "vitest": "^3.0.7"
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
This pull request includes two changes: a fix for the CI release process and a modification to the `package.json` file to remove the `private` field.

### Changes related to CI release:

* [`.changeset/heavy-cows-start.md`](diffhunk://#diff-633e8ad9e010df87ee277f334f853b470ba2498e925af5e01627988738a3dadaR1-R5): Added a patch note indicating a fix for the CI release process under the `omni-bridge-sdk` package.

### Changes to `package.json`:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L58-R58): Removed the `private` field from the configuration, likely to enable publishing or sharing the package.