### PR TITLE
🐛 Fix isSolWallet check logic

### DIFF
--- a/.changeset/light-yaks-enjoy.md
+++ b/.changeset/light-yaks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+🐛 Fix isSolWallet check logic

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,10 @@ type Client =
 // Type guards
 export function isSolWallet(wallet: SolWallet | WalletSelector): wallet is SolWallet {
   return (
-    wallet && typeof wallet === "object" && "publicKey" in wallet && "sendTransaction" in wallet
+    wallet &&
+    typeof wallet === "object" &&
+    "publicKey" in wallet &&
+    "sendTransaction" in (wallet.connection ?? {})
   )
 }
 


### PR DESCRIPTION
By definition of `Provider`, it does not contain a `sendTransaction` method, which will cause `isSolWallet` to always return false.
```ts
export default interface Provider {
    readonly connection: Connection;
    readonly publicKey?: PublicKey;
    send?(tx: Transaction | VersionedTransaction, signers?: Signer[], opts?: SendOptions): Promise<TransactionSignature>;
    sendAndConfirm?(tx: Transaction | VersionedTransaction, signers?: Signer[], opts?: ConfirmOptions): Promise<TransactionSignature>;
    sendAll?<T extends Transaction | VersionedTransaction>(txWithSigners: {
        tx: T;
        signers?: Signer[];
    }[], opts?: ConfirmOptions): Promise<Array<TransactionSignature>>;
    simulate?(tx: Transaction | VersionedTransaction, signers?: Signer[], commitment?: Commitment, includeAccounts?: boolean | PublicKey[]): Promise<SuccessfulTxSimulationResponse>;
}
```