### PR TITLE
feat: add EVM proof support to NEAR deployToken method

### DIFF
--- a/src/clients/near.ts
+++ b/src/clients/near.ts
@@ -160,12 +160,25 @@ export class NearBridgeClient {
    * @param vaa - Verified Action Approval containing deployment information
    * @returns Promise resolving to the transaction hash
    */
-  async deployToken(destinationChain: ChainKind, vaa: string): Promise<string> {
-    const proverArgs: WormholeVerifyProofArgs = {
-      proof_kind: ProofKind.DeployToken,
-      vaa: vaa,
+  async deployToken(
+    destinationChain: ChainKind,
+    vaa?: string,
+    evmProof?: EvmVerifyProofArgs,
+  ): Promise<string> {
+    if (!vaa && !evmProof) {
+      throw new Error("Must provide either VAA or EVM proof")
     }
-    const proverArgsSerialized = WormholeVerifyProofArgsSchema.serialize(proverArgs)
+
+    let proverArgsSerialized: Uint8Array = new Uint8Array(0)
+    if (vaa) {
+      const proverArgs: WormholeVerifyProofArgs = {
+        proof_kind: ProofKind.DeployToken,
+        vaa: vaa,
+      }
+      proverArgsSerialized = WormholeVerifyProofArgsSchema.serialize(proverArgs)
+    } else if (evmProof) {
+      proverArgsSerialized = EvmVerifyProofArgsSchema.serialize(evmProof)
+    }
 
     // Construct deploy token arguments
     const args: DeployTokenArgs = {


### PR DESCRIPTION
## Summary
- Adds optional `evmProof` parameter to `deployToken` method in `NearBridgeClient`
- Implements EVM proof validation and serialization following the same pattern as `bindToken` and `finalizeTransfer`
- Maintains backward compatibility with existing VAA-only usage

## Background
The `deployToken` method was missing EVM proof support while other methods (`bindToken`, `finalizeTransfer`) already supported both VAA and EVM proofs. This created an inconsistency where users could only deploy tokens using Wormhole VAA proofs from EVM chains.

## Changes
- Added `evmProof?: EvmVerifyProofArgs` parameter to method signature  
- Added validation to ensure either `vaa` or `evmProof` is provided
- Added EVM proof serialization using `EvmVerifyProofArgsSchema.serialize()`
- Follows the exact same pattern as existing methods for consistency

## Test plan
- [x] Code passes existing lint checks (`bun run lint`)  
- [x] Code passes TypeScript validation (`bun run typecheck`)
- [ ] Manual testing with EVM proof deployment
- [ ] Unit tests for new functionality (if needed)

Closes #160

## Related
- Addresses feedback from @frolvanya in PR #158