### PR TITLE
fix: isSolWallet check logic

### DIFF
--- a/.changeset/light-yaks-enjoy.md
+++ b/.changeset/light-yaks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+🐛 Fix isSolWallet check logic

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,12 +23,7 @@ type Client =
 
 // Type guards
 export function isSolWallet(wallet: SolWallet | WalletSelector): wallet is SolWallet {
-  return (
-    wallet &&
-    typeof wallet === "object" &&
-    "publicKey" in wallet &&
-    "sendTransaction" in (wallet.connection ?? {})
-  )
+  return wallet && typeof wallet === "object" && "publicKey" in wallet && "send" in wallet
 }
 
 export function isWalletSelector(wallet: SolWallet | WalletSelector): wallet is WalletSelector {

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,10 @@ type Client =
 // Type guards
 export function isSolWallet(wallet: SolWallet | WalletSelector): wallet is SolWallet {
   return (
-    wallet && typeof wallet === "object" && "publicKey" in wallet && "sendTransaction" in wallet
+    wallet &&
+    typeof wallet === "object" &&
+    "publicKey" in wallet &&
+    "sendTransaction" in (wallet.connection ?? {})
   )
 }
 


### PR DESCRIPTION
## Summary
- Fix isSolWallet type guard to check for 'send' method instead of 'sendTransaction'
- The Anchor Provider interface has 'send' method, not 'sendTransaction'
- Corrects the logic from PR #153 which had an incorrect fix

## Test plan
- [x] TypeScript compilation passes
- [x] All tests pass (126/126)
- [x] Biome linting passes