### PR TITLE
Add NEAR to ETH e2e test infrastructure with manual flow

### DIFF
--- a/e2e/eth-to-near.test.ts
+++ b/e2e/eth-to-near.test.ts
@@ -1,0 +1,140 @@
+import { ethers } from "ethers"
+import { beforeAll, describe, expect, test } from "vitest"
+import { EvmBridgeClient } from "../src/clients/evm.js"
+import { NearBridgeClient } from "../src/clients/near.js"
+import { setNetwork } from "../src/config.js"
+import { getEvmProof } from "../src/proofs/evm.js"
+import { ChainKind, type OmniTransferMessage, ProofKind } from "../src/types/index.js"
+import { omniAddress } from "../src/utils/index.js"
+import { ETH_TO_NEAR_ROUTES, TIMEOUTS } from "./shared/fixtures.js"
+import { type TestAccountsSetup, setupTestAccounts } from "./shared/setup.js"
+
+describe("ETH to NEAR E2E Transfer Tests (Manual Flow)", () => {
+  let testAccounts: TestAccountsSetup
+  let ethClient: EvmBridgeClient
+  let nearClient: NearBridgeClient
+
+  beforeAll(async () => {
+    // Set network to testnet for all tests
+    setNetwork("testnet")
+
+    // Setup test accounts and clients
+    testAccounts = await setupTestAccounts()
+    ethClient = new EvmBridgeClient(testAccounts.ethWallet, ChainKind.Eth)
+    nearClient = new NearBridgeClient(testAccounts.nearAccount)
+
+    console.log("🚀 Test setup complete:")
+    console.log(`  ETH Address: ${testAccounts.ethWallet.address}`)
+    console.log(`  NEAR Account: ${testAccounts.nearAccount.accountId}`)
+  }, TIMEOUTS.NETWORK_REQUEST)
+
+  test.each(ETH_TO_NEAR_ROUTES)(
+    "should complete manual ETH to NEAR transfer: $name",
+    async (route) => {
+      console.log(`\n🌉 Testing ${route.name} (Manual Flow)...`)
+
+      // Create transfer message with zero fees (manual flow)
+      const transferMessage: OmniTransferMessage = {
+        tokenAddress: route.token.address,
+        amount: BigInt(route.token.testAmount),
+        recipient: omniAddress(ChainKind.Near, route.recipient),
+        message: "E2E manual test transfer",
+        fee: BigInt(0), // No relayer fee
+        nativeFee: BigInt(0), // No relayer fee
+      }
+
+      console.log("📤 Step 1: Initiating ETH → NEAR transfer...")
+      console.log(`  Token: ${route.token.symbol} (${route.token.address})`)
+      console.log(`  Amount: ${route.token.testAmount}`)
+      console.log(`  From: ${route.sender}`)
+      console.log(`  To: ${transferMessage.recipient}`)
+      console.log("  Fee: 0 (manual flow)")
+
+      // Step 1: Initiate transfer on Ethereum
+      const initResult = await ethClient.initTransfer(transferMessage)
+
+      console.log("✓ Transfer initiated on Ethereum!")
+      console.log(`  Transaction Hash: ${initResult.transactionHash}`)
+
+      // Validate initiation
+      expect(initResult).toHaveProperty("transactionHash")
+      expect(typeof initResult.transactionHash).toBe("string")
+      expect(initResult.transactionHash.length).toBeGreaterThan(0)
+
+      // Step 2: Get the InitTransfer event from the transaction
+      console.log("\n🔍 Step 2: Extracting transfer event from transaction...")
+      const transferEvent = await ethClient.getInitTransferEvent(initResult.transactionHash)
+
+      console.log("✓ Transfer event extracted!")
+      console.log(`  Origin Nonce: ${transferEvent.originNonce}`)
+      console.log(`  Token: ${transferEvent.tokenAddress}`)
+      console.log(`  Amount: ${transferEvent.amount}`)
+      console.log(`  Recipient: ${transferEvent.recipient}`)
+
+      // Validate event extraction
+      expect(transferEvent).toHaveProperty("originNonce")
+      expect(transferEvent).toHaveProperty("tokenAddress")
+      expect(transferEvent).toHaveProperty("amount")
+      expect(transferEvent).toHaveProperty("recipient")
+
+      // Step 3: Generate EVM proof
+      console.log("\n🔒 Step 3: Generating EVM proof...")
+
+      // Calculate the InitTransfer event topic hash
+      // InitTransfer(address indexed sender, address indexed tokenAddress, uint64 indexed originNonce, uint128 amount, uint128 fee, uint128 nativeTokenFee, string recipient, string message)
+      const initTransferSignature =
+        "InitTransfer(address,address,uint64,uint128,uint128,uint128,string,string)"
+      const INIT_TRANSFER_TOPIC = ethers.id(initTransferSignature)
+
+      const proof = await getEvmProof(
+        initResult.transactionHash,
+        INIT_TRANSFER_TOPIC,
+        ChainKind.Eth,
+      )
+
+      console.log("✓ EVM proof generated!")
+      console.log("  Proof length:", proof.proof.length)
+
+      // Validate proof generation
+      expect(proof).toHaveProperty("proof")
+      expect(proof.proof.length).toBeGreaterThan(0)
+
+      // Step 4: Wait for transaction to be finalized
+      console.log("\n⏳ Step 4: Waiting for transaction finalization...")
+      await new Promise((resolve) => setTimeout(resolve, 30000)) // Wait 30s for finalization
+
+      // Step 5: Finalize transfer on NEAR
+      console.log("\n🏁 Step 5: Finalizing transfer on NEAR...")
+
+      // Extract the NEAR token address (remove "eth:" prefix and use equivalent NEAR token)
+      const nearTokenId = "wrap.testnet" // The equivalent NEAR token
+      const storageDepositAmount = "1000000000000000000000000" // 1 NEAR in yoctoNEAR for storage
+
+      const finalizeResult = await nearClient.finalizeTransfer(
+        nearTokenId,
+        route.recipient.split(":")[1], // Remove "near:" prefix
+        BigInt(storageDepositAmount),
+        ChainKind.Eth,
+        undefined, // No VAA needed for EVM
+        proof, // EVM proof required
+        ProofKind.InitTransfer,
+      )
+
+      console.log("✓ Transfer finalized on NEAR!")
+      console.log(`  Finalization TX: ${finalizeResult}`)
+
+      // Validate finalization
+      expect(finalizeResult).toBeDefined()
+      expect(typeof finalizeResult).toBe("string") // Should be transaction hash
+      expect(finalizeResult.length).toBeGreaterThan(0)
+
+      console.log("\n🎉 Manual transfer flow completed successfully!")
+      console.log("  1. ✓ Initiated on ETH")
+      console.log("  2. ✓ Extracted event data")
+      console.log("  3. ✓ Generated EVM proof")
+      console.log("  4. ✓ Finalized on NEAR")
+      console.log(`✅ ${route.name} test completed!`)
+    },
+    TIMEOUTS.FULL_E2E_FLOW,
+  )
+})

--- a/e2e/eth-to-near.test.ts
+++ b/e2e/eth-to-near.test.ts
@@ -51,19 +51,18 @@ describe("ETH to NEAR E2E Transfer Tests (Manual Flow)", () => {
       console.log("  Fee: 0 (manual flow)")
 
       // Step 1: Initiate transfer on Ethereum
-      const initResult = await ethClient.initTransfer(transferMessage)
+      const transactionHash = await ethClient.initTransfer(transferMessage)
 
       console.log("✓ Transfer initiated on Ethereum!")
-      console.log(`  Transaction Hash: ${initResult.transactionHash}`)
+      console.log(`  Transaction Hash: ${transactionHash}`)
 
       // Validate initiation
-      expect(initResult).toHaveProperty("transactionHash")
-      expect(typeof initResult.transactionHash).toBe("string")
-      expect(initResult.transactionHash.length).toBeGreaterThan(0)
+      expect(typeof transactionHash).toBe("string")
+      expect(transactionHash.length).toBeGreaterThan(0)
 
       // Step 2: Get the InitTransfer event from the transaction
       console.log("\n🔍 Step 2: Extracting transfer event from transaction...")
-      const transferEvent = await ethClient.getInitTransferEvent(initResult.transactionHash)
+      const transferEvent = await ethClient.getInitTransferEvent(transactionHash)
 
       console.log("✓ Transfer event extracted!")
       console.log(`  Origin Nonce: ${transferEvent.originNonce}`)
@@ -86,11 +85,7 @@ describe("ETH to NEAR E2E Transfer Tests (Manual Flow)", () => {
         "InitTransfer(address,address,uint64,uint128,uint128,uint128,string,string)"
       const INIT_TRANSFER_TOPIC = ethers.id(initTransferSignature)
 
-      const proof = await getEvmProof(
-        initResult.transactionHash,
-        INIT_TRANSFER_TOPIC,
-        ChainKind.Eth,
-      )
+      const proof = await getEvmProof(transactionHash, INIT_TRANSFER_TOPIC, ChainKind.Eth)
 
       console.log("✓ EVM proof generated!")
       console.log("  Proof length:", proof.proof.length)

--- a/e2e/near-to-eth.test.ts
+++ b/e2e/near-to-eth.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, describe, expect, test } from "vitest"
+import { EvmBridgeClient } from "../src/clients/evm.js"
+import { NearBridgeClient } from "../src/clients/near.js"
+import { setNetwork } from "../src/config.js"
+import { ChainKind, type OmniTransferMessage } from "../src/types/index.js"
+import { omniAddress } from "../src/utils/index.js"
+import { NEAR_TO_ETH_ROUTES, TIMEOUTS } from "./shared/fixtures.js"
+import { type TestAccountsSetup, setupTestAccounts } from "./shared/setup.js"
+
+describe("NEAR to ETH E2E Transfer Tests (Manual Flow)", () => {
+  let testAccounts: TestAccountsSetup
+  let nearClient: NearBridgeClient
+  let ethClient: EvmBridgeClient
+
+  beforeAll(async () => {
+    // Set network to testnet for all tests
+    setNetwork("testnet")
+
+    // Setup test accounts and clients
+    testAccounts = await setupTestAccounts()
+    nearClient = new NearBridgeClient(testAccounts.nearAccount)
+    ethClient = new EvmBridgeClient(testAccounts.ethWallet, ChainKind.Eth)
+
+    console.log("🚀 Test setup complete:")
+    console.log(`  NEAR Account: ${testAccounts.nearAccount.accountId}`)
+    console.log(`  ETH Address: ${testAccounts.ethWallet.address}`)
+  }, TIMEOUTS.NETWORK_REQUEST)
+
+  test.each(NEAR_TO_ETH_ROUTES)(
+    "should complete manual NEAR to ETH transfer: $name",
+    async (route) => {
+      console.log(`\n🌉 Testing ${route.name} (Manual Flow)...`)
+
+      // Create transfer message with zero fees (manual flow)
+      const transferMessage: OmniTransferMessage = {
+        tokenAddress: route.token.address,
+        amount: BigInt(route.token.testAmount),
+        recipient: omniAddress(ChainKind.Eth, route.recipient),
+        message: "E2E manual test transfer",
+        fee: BigInt(0), // No relayer fee
+        nativeFee: BigInt(0), // No relayer fee
+      }
+
+      console.log("📤 Step 1: Initiating NEAR → ETH transfer...")
+      console.log(`  Token: ${route.token.symbol} (${route.token.address})`)
+      console.log(`  Amount: ${route.token.testAmount}`)
+      console.log(`  From: ${route.sender}`)
+      console.log(`  To: ${transferMessage.recipient}`)
+      console.log("  Fee: 0 (manual flow)")
+
+      // Step 1: Initiate transfer on NEAR
+      const initResult = await nearClient.initTransfer(transferMessage)
+
+      console.log("✓ Transfer initiated on NEAR!")
+      console.log(`  Origin Nonce: ${initResult.transfer_message.origin_nonce}`)
+      console.log("  Transfer Message:", JSON.stringify(initResult.transfer_message, null, 2))
+
+      // Validate initiation
+      expect(initResult).toHaveProperty("transfer_message")
+      expect(initResult.transfer_message).toHaveProperty("origin_nonce")
+      expect(initResult.transfer_message.origin_nonce).toBeGreaterThan(0)
+
+      // Step 2: Sign the transfer on NEAR
+      console.log("\n🖋️ Step 2: Signing transfer on NEAR...")
+      const signResult = await nearClient.signTransfer(initResult, route.sender)
+
+      console.log("✓ Transfer signed on NEAR!")
+      console.log("  Signature:", signResult.signature)
+      console.log("  Message Payload:", signResult.message_payload)
+
+      // Validate signing
+      expect(signResult).toHaveProperty("signature")
+      expect(signResult).toHaveProperty("message_payload")
+
+      // Step 3: Finalize transfer on Ethereum
+      console.log("\n🏁 Step 3: Finalizing transfer on Ethereum...")
+
+      // Use the signature and message payload from the sign result
+      const finalizeResult = await ethClient.finalizeTransfer(
+        signResult.message_payload,
+        signResult.signature,
+      )
+
+      console.log("✓ Transfer finalized on Ethereum!")
+      console.log("  Finalization TX:", finalizeResult)
+
+      // Validate finalization
+      expect(finalizeResult).toBeDefined()
+      expect(typeof finalizeResult).toBe("string") // Should be transaction hash
+      expect(finalizeResult.length).toBeGreaterThan(0)
+
+      console.log("\n🎉 Manual transfer flow completed successfully!")
+      console.log("  1. ✓ Initiated on NEAR")
+      console.log("  2. ✓ Signed on NEAR")
+      console.log("  3. ✓ Finalized on ETH")
+      console.log(`✅ ${route.name} test completed!`)
+    },
+    TIMEOUTS.FULL_E2E_FLOW,
+  )
+})

--- a/e2e/near-to-sol.test.ts
+++ b/e2e/near-to-sol.test.ts
@@ -1,0 +1,102 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import { NearBridgeClient } from "../src/clients/near.js"
+import { SolanaBridgeClient } from "../src/clients/solana.js"
+import { setNetwork } from "../src/config.js"
+import { ChainKind, type OmniTransferMessage } from "../src/types/index.js"
+import { omniAddress } from "../src/utils/index.js"
+import { NEAR_TO_SOL_ROUTES, TIMEOUTS } from "./shared/fixtures.js"
+import { type TestAccountsSetup, setupTestAccounts } from "./shared/setup.js"
+
+describe("NEAR to SOL E2E Transfer Tests (Manual Flow)", () => {
+  let testAccounts: TestAccountsSetup
+  let nearClient: NearBridgeClient
+  let solanaClient: SolanaBridgeClient
+
+  beforeAll(async () => {
+    // Set network to testnet for all tests
+    setNetwork("testnet")
+
+    // Setup test accounts and clients
+    testAccounts = await setupTestAccounts()
+    nearClient = new NearBridgeClient(testAccounts.nearAccount)
+    solanaClient = new SolanaBridgeClient(testAccounts.solanaProvider)
+
+    console.log("🚀 Test setup complete:")
+    console.log(`  NEAR Account: ${testAccounts.nearAccount.accountId}`)
+    console.log(`  SOL Address: ${testAccounts.solanaProvider.publicKey.toString()}`)
+  })
+
+  test.each(NEAR_TO_SOL_ROUTES)(
+    "should complete manual NEAR to SOL transfer: $name",
+    async (route) => {
+      console.log(`\n🌉 Testing ${route.name} (Manual Flow)...`)
+
+      // Create transfer message with zero fees (manual flow)
+      // Use the actual Solana wallet address as recipient
+      const solanaRecipient = testAccounts.solanaProvider.publicKey.toString()
+      const transferMessage: OmniTransferMessage = {
+        tokenAddress: route.token.address,
+        amount: BigInt(route.token.testAmount),
+        recipient: omniAddress(ChainKind.Sol, solanaRecipient),
+        message: "E2E manual test transfer",
+        fee: BigInt(0), // No relayer fee
+        nativeFee: BigInt(0), // No relayer fee
+      }
+
+      console.log("📤 Step 1: Initiating NEAR → SOL transfer...")
+      console.log(`  Token: ${route.token.symbol} (${route.token.address})`)
+      console.log(`  Amount: ${route.token.testAmount}`)
+      console.log(`  From: ${route.sender}`)
+      console.log(`  To: ${transferMessage.recipient}`)
+      console.log("  Fee: 0 (manual flow)")
+
+      // Step 1: Initiate transfer on NEAR
+      const initResult = await nearClient.initTransfer(transferMessage)
+
+      console.log("✓ Transfer initiated on NEAR!")
+      console.log(`  Origin Nonce: ${initResult.transfer_message.origin_nonce}`)
+      console.log("  Transfer Message:", JSON.stringify(initResult.transfer_message, null, 2))
+
+      // Validate initiation
+      expect(initResult).toHaveProperty("transfer_message")
+      expect(initResult.transfer_message).toHaveProperty("origin_nonce")
+      expect(initResult.transfer_message.origin_nonce).toBeGreaterThan(0)
+
+      // Step 2: Sign the transfer on NEAR
+      console.log("\n🖋️ Step 2: Signing transfer on NEAR...")
+      const signResult = await nearClient.signTransfer(initResult, route.sender)
+
+      console.log("✓ Transfer signed on NEAR!")
+      console.log("  Signature:", signResult.signature)
+      console.log("  Message Payload:", signResult.message_payload)
+
+      // Validate signing
+      expect(signResult).toHaveProperty("signature")
+      expect(signResult).toHaveProperty("message_payload")
+
+      // Step 3: Finalize transfer on Solana
+      console.log("\n🏁 Step 3: Finalizing transfer on Solana...")
+
+      // Use the signature and message payload from the sign result
+      const finalizeResult = await solanaClient.finalizeTransfer(
+        signResult.message_payload,
+        signResult.signature,
+      )
+
+      console.log("✓ Transfer finalized on Solana!")
+      console.log("  Finalization TX:", finalizeResult)
+
+      // Validate finalization
+      expect(finalizeResult).toBeDefined()
+      expect(typeof finalizeResult).toBe("string") // Should be transaction hash
+      expect(finalizeResult.length).toBeGreaterThan(0)
+
+      console.log("\n🎉 Manual transfer flow completed successfully!")
+      console.log("  1. ✓ Initiated on NEAR")
+      console.log("  2. ✓ Signed on NEAR")
+      console.log("  3. ✓ Finalized on SOL")
+      console.log(`✅ ${route.name} test completed!`)
+    },
+    TIMEOUTS.FULL_E2E_FLOW,
+  )
+})

--- a/e2e/shared/assertions.ts
+++ b/e2e/shared/assertions.ts
@@ -1,0 +1,89 @@
+import { expect } from "bun:test"
+import { OmniBridgeAPI } from "../../src/api.js"
+
+export class TransferAssertions {
+  private api: OmniBridgeAPI
+
+  constructor() {
+    this.api = new OmniBridgeAPI()
+  }
+
+  async validateTransferStatus(
+    originChain: "Near" | "Eth" | "Sol" | "Arb" | "Base",
+    originNonce: number,
+    expectedStatus?: "initialized" | "signed" | "finalised",
+  ): Promise<void> {
+    const status = await this.api.getTransferStatus(originChain, originNonce)
+
+    expect(status).toBeDefined()
+    expect(typeof status).toBe("object")
+
+    console.log(`✓ Transfer status retrieved for ${originChain}:${originNonce}`)
+    console.log("  Status:", JSON.stringify(status, null, 2))
+
+    if (expectedStatus) {
+      // Add specific status validation based on what the API returns
+      expect(status).toHaveProperty(expectedStatus)
+    }
+  }
+
+  async validateTransferCompletion(
+    originChain: "Near" | "Eth" | "Sol" | "Arb" | "Base",
+    originNonce: number,
+  ): Promise<void> {
+    const transfer = await this.api.getTransfer(originChain, originNonce)
+
+    expect(transfer).toBeDefined()
+    expect(transfer).toHaveProperty("id")
+    expect(transfer).toHaveProperty("initialized")
+    expect(transfer).toHaveProperty("transfer_message")
+
+    // Verify the transfer has progressed beyond initialization
+    const hasProgression =
+      transfer.signed !== null || transfer.finalised !== null || transfer.claimed !== null
+
+    if (hasProgression) {
+      console.log("✓ Transfer has progressed beyond initialization")
+    } else {
+      console.log("⚠ Transfer is still in initialization phase")
+    }
+
+    console.log(`✓ Transfer details retrieved for ${originChain}:${originNonce}`)
+    console.log(`  Transfer ID: ${transfer.id.origin_chain}:${transfer.id.origin_nonce}`)
+    console.log(`  Token: ${transfer.transfer_message.token}`)
+    console.log(`  Amount: ${transfer.transfer_message.amount}`)
+    console.log(`  Sender: ${transfer.transfer_message.sender}`)
+    console.log(`  Recipient: ${transfer.transfer_message.recipient}`)
+  }
+
+  async waitForTransferProgression(
+    originChain: "Near" | "Eth" | "Sol" | "Arb" | "Base",
+    originNonce: number,
+    maxWaitTimeMs = 120000, // 2 minutes
+  ): Promise<void> {
+    const startTime = Date.now()
+    const pollInterval = 5000 // 5 seconds
+
+    console.log(`⏳ Waiting for transfer progression (max ${maxWaitTimeMs / 1000}s)...`)
+
+    while (Date.now() - startTime < maxWaitTimeMs) {
+      try {
+        const transfer = await this.api.getTransfer(originChain, originNonce)
+
+        // Check if transfer has progressed beyond initialization
+        if (transfer.signed !== null || transfer.finalised !== null || transfer.claimed !== null) {
+          console.log("✓ Transfer has progressed!")
+          return
+        }
+
+        console.log(`⏳ Still waiting... (${Math.round((Date.now() - startTime) / 1000)}s elapsed)`)
+        await new Promise((resolve) => setTimeout(resolve, pollInterval))
+      } catch (_error) {
+        console.log("⏳ Transfer not found yet, continuing to wait...")
+        await new Promise((resolve) => setTimeout(resolve, pollInterval))
+      }
+    }
+
+    console.log(`⚠ Transfer did not progress within ${maxWaitTimeMs / 1000}s timeout`)
+  }
+}

--- a/e2e/shared/fixtures.ts
+++ b/e2e/shared/fixtures.ts
@@ -1,0 +1,69 @@
+import { ChainKind, type OmniAddress } from "../../src/types/index.js"
+import { omniAddress } from "../../src/utils/index.js"
+
+export interface TestTokenConfig {
+  address: OmniAddress
+  decimals: number
+  symbol: string
+  testAmount: string // Human-readable amount (e.g., "1.0")
+}
+
+export interface TestAddresses {
+  near: {
+    testAccount: string
+    recipient: string
+  }
+  ethereum: {
+    testAccount: string
+    recipient: string
+  }
+}
+
+// Test addresses for NEAR to ETH transfers
+export const TEST_ADDRESSES: TestAddresses = {
+  near: {
+    testAccount: "omni-sdk-test.testnet",
+    recipient: "test-recipient.testnet",
+  },
+  ethereum: {
+    testAccount: "0xA7C29dA7599817edA0f829E7B8d0FFE23D81c4d3", // Your Sepolia address
+    recipient: "0x000000F8637F1731D906643027c789EFA60BfE11", // Test recipient
+  },
+}
+
+// Test tokens for NEAR to ETH transfers
+export const TEST_TOKENS = {
+  // NEAR native token
+  NEAR: {
+    address: omniAddress(ChainKind.Near, "wrap.testnet"),
+    decimals: 24,
+    symbol: "wNEAR",
+    testAmount: "1000000",
+  } satisfies TestTokenConfig,
+}
+
+// NEAR to ETH transfer configuration
+export interface TransferRoute {
+  name: string
+  token: TestTokenConfig
+  sender: string
+  recipient: string
+}
+
+export const NEAR_TO_ETH_ROUTES: TransferRoute[] = [
+  {
+    name: "NEAR → ETH (wNEAR)",
+    token: TEST_TOKENS.NEAR,
+    sender: TEST_ADDRESSES.near.testAccount,
+    recipient: TEST_ADDRESSES.ethereum.testAccount,
+  },
+]
+
+// Timeout configurations for NEAR to ETH transfers
+export const TIMEOUTS = {
+  NETWORK_REQUEST: 30000, // 30 seconds
+  TRANSFER_INITIATION: 60000, // 1 minute
+  PROOF_GENERATION: 120000, // 2 minutes
+  TRANSFER_FINALIZATION: 180000, // 3 minutes
+  FULL_E2E_FLOW: 300000, // 5 minutes
+}

--- a/e2e/shared/fixtures.ts
+++ b/e2e/shared/fixtures.ts
@@ -17,9 +17,13 @@ export interface TestAddresses {
     testAccount: string
     recipient: string
   }
+  solana: {
+    testAccount: string
+    recipient: string
+  }
 }
 
-// Test addresses for NEAR to ETH transfers
+// Test addresses for cross-chain transfers
 export const TEST_ADDRESSES: TestAddresses = {
   near: {
     testAccount: "omni-sdk-test.testnet",
@@ -28,6 +32,10 @@ export const TEST_ADDRESSES: TestAddresses = {
   ethereum: {
     testAccount: "0xA7C29dA7599817edA0f829E7B8d0FFE23D81c4d3", // Your Sepolia address
     recipient: "0x000000F8637F1731D906643027c789EFA60BfE11", // Test recipient
+  },
+  solana: {
+    testAccount: "2sUFgertVaZHxzyMM5z5DajkyU1TnPCMr1yDnTiEsVit", // Your SOL wallet address
+    recipient: "2sUFgertVaZHxzyMM5z5DajkyU1TnPCMr1yDnTiEsVit", // Same as test account for self-transfer
   },
 }
 
@@ -47,6 +55,14 @@ export const TEST_TOKENS = {
     decimals: 24,
     symbol: "NEAR",
     testAmount: "10",
+  } satisfies TestTokenConfig,
+
+  // NEAR token for NEAR → SOL transfers
+  NEAR_TO_SOL: {
+    address: omniAddress(ChainKind.Near, "wrap.testnet"),
+    decimals: 24,
+    symbol: "wNEAR",
+    testAmount: "1000000000000000000",
   } satisfies TestTokenConfig,
 }
 
@@ -73,6 +89,15 @@ export const ETH_TO_NEAR_ROUTES: TransferRoute[] = [
     token: TEST_TOKENS.NEAR_ON_ETH,
     sender: TEST_ADDRESSES.ethereum.testAccount,
     recipient: TEST_ADDRESSES.near.testAccount,
+  },
+]
+
+export const NEAR_TO_SOL_ROUTES: TransferRoute[] = [
+  {
+    name: "NEAR → SOL (wNEAR)",
+    token: TEST_TOKENS.NEAR_TO_SOL,
+    sender: TEST_ADDRESSES.near.testAccount,
+    recipient: TEST_ADDRESSES.solana.testAccount,
   },
 ]
 

--- a/e2e/shared/fixtures.ts
+++ b/e2e/shared/fixtures.ts
@@ -31,18 +31,26 @@ export const TEST_ADDRESSES: TestAddresses = {
   },
 }
 
-// Test tokens for NEAR to ETH transfers
+// Test tokens for bidirectional transfers
 export const TEST_TOKENS = {
-  // NEAR native token
+  // NEAR native token (for NEAR → ETH)
   NEAR: {
     address: omniAddress(ChainKind.Near, "wrap.testnet"),
     decimals: 24,
     symbol: "wNEAR",
     testAmount: "1000000",
   } satisfies TestTokenConfig,
+
+  // NEAR token on Ethereum (for ETH → NEAR)
+  NEAR_ON_ETH: {
+    address: omniAddress(ChainKind.Eth, "0x1f89e263159f541182f875ac05d773657d24eb92"),
+    decimals: 24,
+    symbol: "NEAR",
+    testAmount: "1000000",
+  } satisfies TestTokenConfig,
 }
 
-// NEAR to ETH transfer configuration
+// Transfer route configuration
 export interface TransferRoute {
   name: string
   token: TestTokenConfig
@@ -56,6 +64,15 @@ export const NEAR_TO_ETH_ROUTES: TransferRoute[] = [
     token: TEST_TOKENS.NEAR,
     sender: TEST_ADDRESSES.near.testAccount,
     recipient: TEST_ADDRESSES.ethereum.testAccount,
+  },
+]
+
+export const ETH_TO_NEAR_ROUTES: TransferRoute[] = [
+  {
+    name: "ETH → NEAR (NEAR token)",
+    token: TEST_TOKENS.NEAR_ON_ETH,
+    sender: TEST_ADDRESSES.ethereum.testAccount,
+    recipient: TEST_ADDRESSES.near.testAccount,
   },
 ]
 

--- a/e2e/shared/fixtures.ts
+++ b/e2e/shared/fixtures.ts
@@ -64,6 +64,14 @@ export const TEST_TOKENS = {
     symbol: "wNEAR",
     testAmount: "1000000000000000000",
   } satisfies TestTokenConfig,
+
+  // wNEAR token on Solana (for SOL → NEAR)
+  WNEAR_ON_SOL: {
+    address: omniAddress(ChainKind.Sol, "3wQct2e43J1Z99h2RWrhPAhf6E32ZpuzEt6tgwfEAKAy"),
+    decimals: 24,
+    symbol: "wNEAR",
+    testAmount: "10", // 1 wNEAR in smallest units
+  } satisfies TestTokenConfig,
 }
 
 // Transfer route configuration
@@ -98,6 +106,15 @@ export const NEAR_TO_SOL_ROUTES: TransferRoute[] = [
     token: TEST_TOKENS.NEAR_TO_SOL,
     sender: TEST_ADDRESSES.near.testAccount,
     recipient: TEST_ADDRESSES.solana.testAccount,
+  },
+]
+
+export const SOL_TO_NEAR_ROUTES: TransferRoute[] = [
+  {
+    name: "SOL → NEAR (wNEAR)",
+    token: TEST_TOKENS.WNEAR_ON_SOL,
+    sender: TEST_ADDRESSES.solana.testAccount,
+    recipient: TEST_ADDRESSES.near.testAccount,
   },
 ]
 

--- a/e2e/shared/fixtures.ts
+++ b/e2e/shared/fixtures.ts
@@ -46,7 +46,7 @@ export const TEST_TOKENS = {
     address: omniAddress(ChainKind.Eth, "0x1f89e263159f541182f875ac05d773657d24eb92"),
     decimals: 24,
     symbol: "NEAR",
-    testAmount: "1000000",
+    testAmount: "10",
   } satisfies TestTokenConfig,
 }
 

--- a/e2e/shared/setup.ts
+++ b/e2e/shared/setup.ts
@@ -1,0 +1,91 @@
+import os from "node:os"
+import path from "node:path"
+import { Account } from "@near-js/accounts"
+import { getSignerFromKeystore } from "@near-js/client"
+import { UnencryptedFileSystemKeyStore } from "@near-js/keystores-node"
+import { JsonRpcProvider } from "@near-js/providers"
+import { ethers } from "ethers"
+
+export interface TestConfig {
+  timeout: number
+  networks: {
+    near: {
+      accountId: string
+      networkId: "testnet" | "mainnet"
+      contractId: string
+      rpcUrl: string
+      credentialsPath: string
+    }
+    ethereum: {
+      rpcUrl: string
+      chainId: number
+      privateKey?: string
+    }
+  }
+}
+
+export const TEST_CONFIG: TestConfig = {
+  timeout: 30000, // 30 second timeout for network operations
+  networks: {
+    near: {
+      accountId: "omni-sdk-test.testnet",
+      networkId: "testnet",
+      contractId: "v1.signer-prod.testnet",
+      rpcUrl: "https://rpc.testnet.near.org",
+      credentialsPath: path.join(os.homedir(), ".near-credentials"),
+    },
+    ethereum: {
+      rpcUrl: "https://ethereum-sepolia-rpc.publicnode.com",
+      chainId: 11155111, // Sepolia
+      privateKey: process.env.ETH_PRIVATE_KEY,
+    },
+  },
+}
+
+export async function createNearAccount(): Promise<Account> {
+  const { near } = TEST_CONFIG.networks
+
+  // Use environment variable in CI, fallback to keystore file locally
+  const privateKey = process.env.NEAR_PRIVATE_KEY
+  if (privateKey) {
+    // CI environment - use private key from environment
+    const { InMemoryKeyStore } = await import("@near-js/keystores")
+    const { KeyPair } = await import("@near-js/crypto")
+    const keyStore = new InMemoryKeyStore()
+    // biome-ignore lint/suspicious/noExplicitAny: NEAR KeyPair typing issue
+    const keyPair = KeyPair.fromString(privateKey as any)
+    await keyStore.setKey(near.networkId, near.accountId, keyPair)
+    const signer = await getSignerFromKeystore(near.accountId, near.networkId, keyStore)
+    const provider = new JsonRpcProvider({ url: near.rpcUrl })
+    return new Account(near.accountId, provider, signer)
+  }
+
+  // Local development - use keystore file
+  const keyStore = new UnencryptedFileSystemKeyStore(near.credentialsPath)
+  const signer = await getSignerFromKeystore(near.accountId, near.networkId, keyStore)
+  const provider = new JsonRpcProvider({ url: near.rpcUrl })
+  return new Account(near.accountId, provider, signer)
+}
+
+export async function createEthereumWallet(): Promise<ethers.Wallet> {
+  const { ethereum } = TEST_CONFIG.networks
+
+  if (!ethereum.privateKey) {
+    throw new Error("ETH_PRIVATE_KEY environment variable required for Ethereum tests")
+  }
+
+  const provider = new ethers.JsonRpcProvider(ethereum.rpcUrl)
+  return new ethers.Wallet(ethereum.privateKey, provider)
+}
+
+export interface TestAccountsSetup {
+  nearAccount: Account
+  ethWallet: ethers.Wallet
+}
+
+export async function setupTestAccounts(): Promise<TestAccountsSetup> {
+  return {
+    nearAccount: await createNearAccount(),
+    ethWallet: await createEthereumWallet(),
+  }
+}

--- a/e2e/sol-to-near-failure.test.ts
+++ b/e2e/sol-to-near-failure.test.ts
@@ -1,0 +1,112 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import { NearBridgeClient } from "../src/clients/near.js"
+import { SolanaBridgeClient } from "../src/clients/solana.js"
+import { setNetwork } from "../src/config.js"
+import { getVaa } from "../src/proofs/wormhole.js"
+import { ChainKind, type OmniTransferMessage, ProofKind } from "../src/types/index.js"
+import { omniAddress } from "../src/utils/index.js"
+import { TIMEOUTS } from "./shared/fixtures.js"
+import { type TestAccountsSetup, setupTestAccounts } from "./shared/setup.js"
+
+describe("SOL to NEAR E2E Transfer Tests - Failure Cases (Manual Flow)", () => {
+  let testAccounts: TestAccountsSetup
+  let solanaClient: SolanaBridgeClient
+  let nearClient: NearBridgeClient
+
+  beforeAll(async () => {
+    // Set network to testnet for all tests
+    setNetwork("testnet")
+
+    // Setup test accounts and clients
+    testAccounts = await setupTestAccounts()
+    solanaClient = new SolanaBridgeClient(testAccounts.solanaProvider)
+    nearClient = new NearBridgeClient(testAccounts.nearAccount)
+
+    console.log("🚀 Test setup complete:")
+    console.log(`  SOL Address: ${testAccounts.solanaProvider.publicKey.toString()}`)
+    console.log(`  NEAR Account: ${testAccounts.nearAccount.accountId}`)
+  })
+
+  test(
+    "should handle finalization failure with panic message",
+    async () => {
+      console.log("\n🌉 Testing SOL → NEAR transfer with expected failure...")
+
+      // Create transfer message with panic-inducing message
+      const transferMessage: OmniTransferMessage = {
+        tokenAddress: omniAddress(ChainKind.Sol, "3wQct2e43J1Z99h2RWrhPAhf6E32ZpuzEt6tgwfEAKAy"), // wNEAR on SOL
+        amount: BigInt("10"), // Small test amount
+        recipient: omniAddress(ChainKind.Near, "heavenly-interest.testnet"), // Mock tocken receiver
+        message: JSON.stringify({
+          return_value: "0",
+          panic: true,
+          extra_msg: "Triggering panic for testing",
+        }),
+        fee: BigInt(0), // No relayer fee
+        nativeFee: BigInt(0), // No relayer fee
+      }
+
+      console.log("📤 Step 1: Initiating SOL → NEAR transfer...")
+      console.log(`  Token: wNEAR (${transferMessage.tokenAddress})`)
+      console.log(`  Amount: ${transferMessage.amount}`)
+      console.log(`  From: ${testAccounts.solanaProvider.publicKey.toString()}`)
+      console.log(`  To: ${transferMessage.recipient}`)
+      console.log(`  Message: ${transferMessage.message}`)
+      console.log("  Fee: 0 (manual flow)")
+
+      // Step 1: Initiate transfer on Solana
+      const transactionHash = await solanaClient.initTransfer(transferMessage)
+
+      console.log("✓ Transfer initiated on Solana!")
+      console.log(`  Transaction Hash: ${transactionHash}`)
+
+      // Validate initiation
+      expect(typeof transactionHash).toBe("string")
+      expect(transactionHash.length).toBeGreaterThan(0)
+
+      // Step 2: Get Wormhole VAA
+      console.log("\n🔒 Step 2: Getting Wormhole VAA...")
+      const vaa = await getVaa(transactionHash, "Testnet")
+
+      console.log("✓ Wormhole VAA retrieved!")
+      console.log("  VAA length:", vaa.length)
+
+      // Validate VAA retrieval
+      expect(vaa).toBeDefined()
+      expect(typeof vaa).toBe("string")
+      expect(vaa.length).toBeGreaterThan(0)
+
+      // Step 4: Attempt to finalize transfer on NEAR (should fail)
+      console.log("\n🏁 Step 4: Attempting to finalize transfer on NEAR (expecting failure)...")
+
+      const nearTokenId = "wrap.testnet" // The equivalent NEAR token
+
+      const finalizeResult = await nearClient.finalizeTransfer(
+        nearTokenId,
+        "heavenly-interest.testnet",
+        BigInt(0),
+        ChainKind.Sol,
+        vaa, // Wormhole VAA
+        undefined, // No EVM proof needed for SOL
+        ProofKind.InitTransfer,
+      )
+
+      // Get all receipts from the tx hash
+      const refundLog = finalizeResult.receipts_outcome
+        .flatMap((receipt) => receipt.outcome.logs)
+        .find((log) =>
+          log.includes(
+            "Refund 10000000000000000 from heavenly-interest.testnet to omni.n-bridge.testnet",
+          ),
+        )
+      expect(refundLog).toBeDefined()
+
+      console.log("\n🎉 Failure test completed successfully!")
+      console.log("  1. ✓ Initiated on SOL")
+      console.log("  2. ✓ Got Wormhole VAA")
+      console.log("  3. ✓ Finalization failed as expected")
+      console.log("✅ Panic message test completed!")
+    },
+    TIMEOUTS.FULL_E2E_FLOW,
+  )
+})

--- a/e2e/sol-to-near.test.ts
+++ b/e2e/sol-to-near.test.ts
@@ -1,0 +1,106 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import { NearBridgeClient } from "../src/clients/near.js"
+import { SolanaBridgeClient } from "../src/clients/solana.js"
+import { setNetwork } from "../src/config.js"
+import { getVaa } from "../src/proofs/wormhole.js"
+import { ChainKind, type OmniTransferMessage, ProofKind } from "../src/types/index.js"
+import { omniAddress } from "../src/utils/index.js"
+import { SOL_TO_NEAR_ROUTES, TIMEOUTS } from "./shared/fixtures.js"
+import { type TestAccountsSetup, setupTestAccounts } from "./shared/setup.js"
+
+describe("SOL to NEAR E2E Transfer Tests (Manual Flow)", () => {
+  let testAccounts: TestAccountsSetup
+  let solanaClient: SolanaBridgeClient
+  let nearClient: NearBridgeClient
+
+  beforeAll(async () => {
+    // Set network to testnet for all tests
+    setNetwork("testnet")
+
+    // Setup test accounts and clients
+    testAccounts = await setupTestAccounts()
+    solanaClient = new SolanaBridgeClient(testAccounts.solanaProvider)
+    nearClient = new NearBridgeClient(testAccounts.nearAccount)
+
+    console.log("🚀 Test setup complete:")
+    console.log(`  SOL Address: ${testAccounts.solanaProvider.publicKey.toString()}`)
+    console.log(`  NEAR Account: ${testAccounts.nearAccount.accountId}`)
+  })
+
+  test.each(SOL_TO_NEAR_ROUTES)(
+    "should complete manual SOL to NEAR transfer: $name",
+    async (route) => {
+      console.log(`\n🌉 Testing ${route.name} (Manual Flow)...`)
+
+      // Create transfer message with zero fees (manual flow)
+      const transferMessage: OmniTransferMessage = {
+        tokenAddress: route.token.address,
+        amount: BigInt(route.token.testAmount),
+        recipient: omniAddress(ChainKind.Near, route.recipient),
+        message: "E2E manual test transfer",
+        fee: BigInt(0), // No relayer fee
+        nativeFee: BigInt(0), // No relayer fee
+      }
+
+      console.log("📤 Step 1: Initiating SOL → NEAR transfer...")
+      console.log(`  Token: ${route.token.symbol} (${route.token.address})`)
+      console.log(`  Amount: ${route.token.testAmount}`)
+      console.log(`  From: ${route.sender}`)
+      console.log(`  To: ${transferMessage.recipient}`)
+      console.log("  Fee: 0 (manual flow)")
+
+      // Step 1: Initiate transfer on Solana
+      const transactionHash = await solanaClient.initTransfer(transferMessage)
+
+      console.log("✓ Transfer initiated on Solana!")
+      console.log(`  Transaction Hash: ${transactionHash}`)
+
+      // Validate initiation
+      expect(typeof transactionHash).toBe("string")
+      expect(transactionHash.length).toBeGreaterThan(0)
+
+      // Step 2: Get Wormhole VAA
+      console.log("\n🔒 Step 2: Getting Wormhole VAA...")
+      const vaa = await getVaa(transactionHash, "Testnet")
+
+      console.log("✓ Wormhole VAA retrieved!")
+      console.log("  VAA length:", vaa.length)
+
+      // Validate VAA retrieval
+      expect(vaa).toBeDefined()
+      expect(typeof vaa).toBe("string")
+      expect(vaa.length).toBeGreaterThan(0)
+
+      // Step 3: Finalize transfer on NEAR
+      console.log("\n🏁 Step 3: Finalizing transfer on NEAR...")
+
+      // Extract the NEAR token ID (equivalent of the Solana wNEAR token)
+      const nearTokenId = "wrap.testnet" // The equivalent NEAR token
+
+      const finalizeResult = await nearClient.finalizeTransfer(
+        nearTokenId,
+        route.recipient,
+        BigInt(0),
+        ChainKind.Sol,
+        vaa, // Wormhole VAA
+        undefined, // No EVM proof needed for SOL
+        ProofKind.InitTransfer,
+      )
+
+      console.log("✓ Transfer finalized on NEAR!")
+      console.log(`  Finalization TX: ${finalizeResult}`)
+
+      // Validate finalization
+      expect(finalizeResult).toBeDefined()
+      expect(typeof finalizeResult.transaction.tx).toBe("string") // Should be transaction hash
+      expect(finalizeResult.transaction.tx.length).toBeGreaterThan(0)
+
+      console.log("\n🎉 Manual transfer flow completed successfully!")
+      console.log("  1. ✓ Initiated on SOL")
+      console.log("  2. ✓ Got Wormhole VAA")
+      console.log("  3. ✓ Finalized on NEAR")
+      console.log(`✅ ${route.name} test completed!`)
+    },
+    TIMEOUTS.FULL_E2E_FLOW,
+  )
+})

--- a/src/clients/evm.ts
+++ b/src/clients/evm.ts
@@ -185,14 +185,15 @@ export class EvmBridgeClient {
   ): Promise<string> {
     // Convert the transfer message to EVM-compatible format
     const bridgeDeposit: BridgeDeposit = {
-      destination_nonce: BigInt(transferMessage.destination_nonce),
-      origin_chain: Number(transferMessage.transfer_id.origin_chain),
-      origin_nonce: BigInt(transferMessage.transfer_id.origin_nonce),
-      token_address: transferMessage.token_address.split(":")[1],
+      destinationNonce: BigInt(transferMessage.destination_nonce),
+      originChain: Number(ChainKind[Number(transferMessage.transfer_id.origin_chain)]),
+      originNonce: BigInt(transferMessage.transfer_id.origin_nonce),
+      tokenAddress: transferMessage.token_address.split(":")[1],
       amount: BigInt(transferMessage.amount),
       recipient: transferMessage.recipient.split(":")[1],
-      fee_recipient: transferMessage.fee_recipient ?? "",
+      feeRecipient: transferMessage.fee_recipient ?? "",
     }
+    console.log("Bridge Deposit", bridgeDeposit)
 
     try {
       const tx = await this.factory.finTransfer(signature.toBytes(true), bridgeDeposit)

--- a/src/clients/near.ts
+++ b/src/clients/near.ts
@@ -1,5 +1,6 @@
 import type { Account } from "@near-js/accounts"
 import { actionCreators } from "@near-js/transactions"
+import type { FinalExecutionOutcome } from "@near-js/types"
 import { addresses } from "../config.js"
 import {
   type AccountId,
@@ -445,7 +446,7 @@ export class NearBridgeClient {
     vaa?: string,
     evmProof?: EvmVerifyProofArgs,
     proofKind: ProofKind = ProofKind.InitTransfer,
-  ): Promise<string> {
+  ): Promise<FinalExecutionOutcome> {
     if (!vaa && !evmProof) {
       throw new Error("Must provide either VAA or EVM proof")
     }
@@ -506,7 +507,7 @@ export class NearBridgeClient {
       ],
       waitUntil: "FINAL",
     })
-    return tx.transaction.hash
+    return tx
   }
 
   /**

--- a/src/clients/near.ts
+++ b/src/clients/near.ts
@@ -461,13 +461,13 @@ export class NearBridgeClient {
     let proverArgsSerialized: Uint8Array = new Uint8Array(0)
     if (vaa) {
       const proverArgs: WormholeVerifyProofArgs = {
-        proof_kind: proofKind,
+        proof_kind: evmProof?.proof_kind ?? proofKind,
         vaa: vaa,
       }
       proverArgsSerialized = WormholeVerifyProofArgsSchema.serialize(proverArgs)
     } else if (evmProof) {
       const proverArgs: EvmVerifyProofArgs = {
-        proof_kind: proofKind,
+        proof_kind: evmProof.proof_kind ?? proofKind,
         proof: evmProof.proof,
       }
       proverArgsSerialized = EvmVerifyProofArgsSchema.serialize(proverArgs)
@@ -492,7 +492,7 @@ export class NearBridgeClient {
       "required_balance_for_fin_transfer",
       {},
     )
-    const finDeposit = BigInt(finDepositStr as string)
+    const finDeposit = BigInt(finDepositStr as string) + storageDepositAmount
 
     const tx = await this.wallet.signAndSendTransaction({
       receiverId: this.lockerAddress,
@@ -504,6 +504,7 @@ export class NearBridgeClient {
           BigInt(finDeposit),
         ),
       ],
+      waitUntil: "FINAL",
     })
     return tx.transaction.hash
   }

--- a/src/clients/solana.ts
+++ b/src/clients/solana.ts
@@ -120,6 +120,12 @@ export class SolanaBridgeClient {
     )
   }
 
+  async getConfig() {
+    const [configPubkey] = this.config()
+    const configAccount = await this.program.account.config.fetch(configPubkey)
+    return configAccount
+  }
+
   /**
    * Logs metadata for a token
    * @param token - The token's public key
@@ -284,7 +290,9 @@ export class SolanaBridgeClient {
         [payerPubKey.toBuffer(), tokenProgram.toBuffer(), mint.toBuffer()],
         ASSOCIATED_TOKEN_PROGRAM_ID,
       )
-      const vault = (await this.isBridgedToken(mint)) ? null : this.vaultId(mint)[0]
+      const vault = (await this.isBridgedToken(mint))
+        ? this.program.programId
+        : this.vaultId(mint)[0]
 
       method = this.program.methods
         .initTransfer({
@@ -348,32 +356,35 @@ export class SolanaBridgeClient {
   async finalizeTransfer(
     transferMessage: TransferMessagePayload,
     signature: MPCSignature,
+    payer?: Keypair,
   ): Promise<string> {
     // Convert the payload into the expected format
+    const originChain: number = Number(
+      ChainKind[transferMessage.transfer_id.origin_chain.toString() as keyof typeof ChainKind],
+    )
+    const payerPk = payer?.publicKey ?? this.program.provider.publicKey
+
     const payload: DepositPayload = {
-      destination_nonce: BigInt(transferMessage.destination_nonce),
-      transfer_id: {
-        origin_chain: transferMessage.transfer_id.origin_chain,
-        origin_nonce: transferMessage.transfer_id.origin_nonce,
+      destinationNonce: new BN(transferMessage.destination_nonce),
+      transferId: {
+        originChain,
+        originNonce: new BN(transferMessage.transfer_id.origin_nonce),
       },
-      token: this.extractSolanaAddress(transferMessage.token_address),
-      amount: BigInt(transferMessage.amount),
-      recipient: this.extractSolanaAddress(transferMessage.recipient),
-      fee_recipient: transferMessage.fee_recipient ?? "",
+      amount: new BN(transferMessage.amount),
+      feeRecipient: transferMessage.fee_recipient ?? "",
     }
 
     const wormholeMessage = Keypair.generate()
-    const recipientPubkey = new PublicKey(payload.recipient)
-    const tokenPubkey = new PublicKey(payload.token)
+    const recipientPubkey = new PublicKey(this.extractSolanaAddress(transferMessage.recipient))
+    const tokenPubkey = new PublicKey(this.extractSolanaAddress(transferMessage.token_address))
 
     // Calculate all the required PDAs
     const [config] = this.config()
     const [authority] = this.authority()
-    // Removed unused solVault declaration
 
     // Calculate nonce account
     const USED_NONCES_PER_ACCOUNT = 1024
-    const nonceGroup = payload.destination_nonce / BigInt(USED_NONCES_PER_ACCOUNT)
+    const nonceGroup = payload.destinationNonce.div(new BN(USED_NONCES_PER_ACCOUNT))
     const [usedNonces] = PublicKey.findProgramAddressSync(
       [
         Buffer.from("used_nonces", "utf-8"),
@@ -390,52 +401,50 @@ export class SolanaBridgeClient {
     )
 
     // Calculate vault if needed
-    const vault = (await this.isBridgedToken(tokenPubkey)) ? null : this.vaultId(tokenPubkey)[0]
+    const vault = (await this.isBridgedToken(tokenPubkey))
+      ? this.program.programId
+      : this.vaultId(tokenPubkey)[0]
 
-    try {
-      const tx = await this.program.methods
-        .finalizeTransfer({
-          payload: {
-            destinationNonce: new BN(payload.destination_nonce.toString()),
-            transferId: {
-              originChain: payload.transfer_id.origin_chain,
-              originNonce: new BN(payload.transfer_id.origin_nonce.toString()),
-            },
-            amount: new BN(payload.amount.toString()),
-            feeRecipient: payload.fee_recipient,
-          },
-          signature: [...signature.toBytes()],
-        })
-        .accountsStrict({
-          usedNonces,
-          authority,
-          recipient: recipientPubkey,
-          mint: tokenPubkey,
-          vault,
-          tokenAccount: recipientATA,
-          common: {
-            payer: this.program.provider.publicKey,
-            config,
-            bridge: this.wormholeBridgeId()[0],
-            feeCollector: this.wormholeFeeCollectorId()[0],
-            sequence: this.wormholeSequenceId()[0],
-            clock: SYSVAR_CLOCK_PUBKEY,
-            rent: SYSVAR_RENT_PUBKEY,
-            systemProgram: SystemProgram.programId,
-            wormholeProgram: this.wormholeProgramId,
-            message: wormholeMessage.publicKey,
-          },
+    const tx = await this.program.methods
+      .finalizeTransfer({
+        payload: payload,
+        signature: [...signature.toBytes()],
+      })
+      .accountsStrict({
+        usedNonces,
+        authority,
+        recipient: recipientPubkey,
+        mint: tokenPubkey,
+        vault,
+        tokenAccount: recipientATA,
+        common: {
+          payer: payerPk,
+          config,
+          bridge: this.wormholeBridgeId()[0],
+          feeCollector: this.wormholeFeeCollectorId()[0],
+          sequence: this.wormholeSequenceId()[0],
+          clock: SYSVAR_CLOCK_PUBKEY,
+          rent: SYSVAR_RENT_PUBKEY,
           systemProgram: SystemProgram.programId,
-          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-          tokenProgram: tokenProgram,
-        })
-        .signers([wormholeMessage])
-        .rpc()
+          wormholeProgram: this.wormholeProgramId,
+          message: wormholeMessage.publicKey,
+        },
+        systemProgram: SystemProgram.programId,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        tokenProgram: tokenProgram,
+      })
+      .signers(payer instanceof Keypair ? [wormholeMessage, payer] : [wormholeMessage])
 
-      return tx
-    } catch (e) {
-      throw new Error(`Failed to finalize transfer: ${e}`)
-    }
+    const ix = await tx.instruction()
+    console.log(
+      ix.keys.map((k) => ({
+        pubkey: k.pubkey.toBase58(),
+        isWritable: k.isWritable,
+        isSigner: k.isSigner,
+      })),
+    )
+
+    return tx.rpc()
   }
 
   private extractSolanaAddress(address: OmniAddress): string {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,0 +1,3 @@
+const chain = "Near"
+
+console.log(chain)

--- a/src/proofs/evm.ts
+++ b/src/proofs/evm.ts
@@ -3,6 +3,7 @@ import { RLP } from "@ethereumjs/rlp"
 import { MapDB, bigIntToHex } from "@ethereumjs/util"
 import type { BlockTag, Log, TransactionReceipt, TransactionReceiptParams } from "ethers"
 import { ethers } from "ethers"
+import { getNetwork } from "../config.js"
 import { ChainKind, type EvmProof } from "../types/index.js"
 import type { EVMChainKind } from "../utils/chain.js"
 
@@ -30,16 +31,24 @@ interface BlockHeader {
   requestsHash?: string
 }
 
-const RPC_URLS: Record<EVMChainKind, string> = {
-  [ChainKind.Eth]: "https://eth.llamarpc.com",
-  [ChainKind.Base]: "https://mainnet.base.org",
-  [ChainKind.Arb]: "https://arb1.arbitrum.io/rpc",
+const RPC_URLS: Record<"mainnet" | "testnet", Record<EVMChainKind, string>> = {
+  mainnet: {
+    [ChainKind.Eth]: "https://eth.llamarpc.com",
+    [ChainKind.Base]: "https://mainnet.base.org",
+    [ChainKind.Arb]: "https://arb1.arbitrum.io/rpc",
+  },
+  testnet: {
+    [ChainKind.Eth]: "https://ethereum-sepolia.publicnode.com",
+    [ChainKind.Base]: "https://sepolia.base.org",
+    [ChainKind.Arb]: "https://sepolia-rollup.arbitrum.io/rpc",
+  },
 }
 
 function getChainRpcUrl(chain: EVMChainKind): string {
-  const url = RPC_URLS[chain]
+  const network = getNetwork()
+  const url = RPC_URLS[network][chain]
   if (!url) {
-    throw new Error(`No RPC URL configured for chain: ${chain}`)
+    throw new Error(`No RPC URL configured for chain: ${chain} on network: ${network}`)
   }
   return url
 }
@@ -62,8 +71,9 @@ export async function getEvmProof(
   txHash: string,
   topic: string,
   chain: EVMChainKind = ChainKind.Eth,
+  customRpcUrl?: string,
 ): Promise<EvmProof> {
-  const rpcUrl = getChainRpcUrl(chain)
+  const rpcUrl = customRpcUrl || getChainRpcUrl(chain)
 
   const provider = new ExtendedProvider(rpcUrl)
   const receipt = await provider.getTransactionReceipt(txHash)

--- a/src/proofs/wormhole.ts
+++ b/src/proofs/wormhole.ts
@@ -4,7 +4,7 @@ import solana from "@wormhole-foundation/sdk/solana"
 
 export async function getVaa(txHash: string, network: "Mainnet" | "Testnet" | "Devnet") {
   const wh = await wormhole(network, [evm, solana])
-  const result = await wh.getVaa(txHash, "Uint8Array", 60_000)
+  const result = await wh.getVaa(txHash, "Uint8Array", 120_000)
   if (!result) {
     throw new Error("No VAA found")
   }

--- a/src/types/evm.ts
+++ b/src/types/evm.ts
@@ -7,19 +7,19 @@ export enum PayloadType {
 }
 
 export interface TransferId {
-  origin_chain: number // u8 in rust
+  origin_chain: number | string // u8 in rust
   origin_nonce: bigint
 }
 
 // bridge deposit structure for evm chains
 export type BridgeDeposit = {
-  destination_nonce: Nonce
-  origin_chain: number // u8 in rust
-  origin_nonce: Nonce
-  token_address: string // evm address
+  destinationNonce: Nonce
+  originChain: number // u8 in rust
+  originNonce: Nonce
+  tokenAddress: string // evm address
   amount: bigint // uint128 in solidity
   recipient: string // evm address
-  fee_recipient: string
+  feeRecipient: string
 }
 
 export type TransferMessagePayload = {

--- a/src/types/sol.ts
+++ b/src/types/sol.ts
@@ -1,11 +1,11 @@
-import type { U128 } from "./common.js"
-import type { TransferId } from "./evm.js"
+import type BN from "bn.js"
 
 export interface DepositPayload {
-  destination_nonce: bigint
-  transfer_id: TransferId
-  token: string
-  amount: U128
-  recipient: string
-  fee_recipient: string | null
+  destinationNonce: BN
+  transferId: {
+    originChain: number
+    originNonce: BN
+  }
+  amount: BN
+  feeRecipient: string | null
 }

--- a/src/types/solana/bridge_token_factory.json
+++ b/src/types/solana/bridge_token_factory.json
@@ -225,7 +225,8 @@
           "name": "recipient"
         },
         {
-          "name": "mint"
+          "name": "mint",
+          "writable": true
         },
         {
           "name": "vault",


### PR DESCRIPTION
- Add e2e test directory with shared setup, fixtures, and assertions
- Implement complete manual flow: initiate → sign → finalize
- Support NEAR, ETH, SOL clients for bidirectional testing
- Use zero fees to avoid relayer dependency
