### PR TITLE
feat: add wormhole post message shim support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,8 @@ const ADDRESSES = {
     sol: {
       locker: "dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe",
       wormhole: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth",
+      shimProgram: "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX",
+      eventAuthority: "HQS31aApX3DDkuXgSpV9XyDUNtFgQ31pUn5BNWHG2PSp",
     },
   },
   testnet: {
@@ -19,6 +21,8 @@ const ADDRESSES = {
     sol: {
       locker: "862HdJV59Vp83PbcubUnvuXc4EAXP8CDDs6LTxFpunTe",
       wormhole: "3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5",
+      shimProgram: "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX",
+      eventAuthority: "HQS31aApX3DDkuXgSpV9XyDUNtFgQ31pUn5BNWHG2PSp",
     },
   },
 } as const

--- a/src/types/solana/bridge_token_factory_shim.json
+++ b/src/types/solana/bridge_token_factory_shim.json
@@ -1,0 +1,1959 @@
+{
+  "address": "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p",
+  "metadata": {
+    "name": "bridge_token_factory",
+    "version": "0.2.5",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "deploy_token",
+      "discriminator": [144, 104, 20, 192, 18, 112, 224, 140],
+      "accounts": [
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [119, 114, 97, 112, 112, 101, 100, 95, 109, 105, 110, 116]
+              },
+              {
+                "kind": "arg",
+                "path": "data.payload.token"
+              }
+            ]
+          }
+        },
+        {
+          "name": "metadata",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 101, 116, 97, 100, 97, 116, 97]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  11, 112, 101, 177, 227, 209, 124, 69, 56, 157, 82, 127, 107, 4, 195, 205, 88, 184,
+                  108, 115, 26, 160, 253, 181, 73, 182, 209, 188, 3, 248, 41, 70
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                11, 112, 101, 177, 227, 209, 124, 69, 56, 157, 82, 127, 107, 4, 195, 205, 88, 184,
+                108, 115, 26, 160, 253, 181, 73, 182, 209, 188, 3, 248, 41, 70
+              ]
+            }
+          }
+        },
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "docs": ["Used as an emitter"],
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [99, 111, 110, 102, 105, 103]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "bridge",
+              "docs": [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [66, 114, 105, 100, 103, 101]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "fee_collector",
+              "docs": [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sequence",
+              "docs": [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "message",
+              "docs": [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ],
+                "program": {
+                  "kind": "const",
+                  "value": [
+                    206, 93, 34, 116, 131, 143, 202, 41, 198, 209, 143, 152, 10, 211, 213, 245, 235,
+                    78, 129, 210, 121, 29, 243, 98, 128, 136, 144, 147, 38, 68, 208, 24
+                  ]
+                }
+              }
+            },
+            {
+              "name": "payer",
+              "writable": true,
+              "signer": true
+            },
+            {
+              "name": "clock",
+              "address": "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              "name": "rent",
+              "address": "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_program",
+              "docs": ["Wormhole program."],
+              "address": "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              "name": "system_program",
+              "address": "11111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_post_message_shim",
+              "address": "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              "name": "wormhole_post_message_shim_ea",
+              "docs": [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_metadata_program",
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        }
+      ],
+      "args": [
+        {
+          "name": "data",
+          "type": {
+            "defined": {
+              "name": "SignedPayload",
+              "generics": [
+                {
+                  "kind": "type",
+                  "type": {
+                    "defined": {
+                      "name": "DeployTokenPayload"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "finalize_transfer",
+      "discriminator": [124, 126, 103, 188, 144, 65, 135, 51],
+      "accounts": [
+        {
+          "name": "used_nonces",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              }
+            ]
+          }
+        },
+        {
+          "name": "recipient"
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "vault",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "recipient"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28,
+                  180, 133, 237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19,
+                153, 218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "docs": ["Used as an emitter"],
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [99, 111, 110, 102, 105, 103]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "bridge",
+              "docs": [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [66, 114, 105, 100, 103, 101]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "fee_collector",
+              "docs": [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sequence",
+              "docs": [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "message",
+              "docs": [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ],
+                "program": {
+                  "kind": "const",
+                  "value": [
+                    206, 93, 34, 116, 131, 143, 202, 41, 198, 209, 143, 152, 10, 211, 213, 245, 235,
+                    78, 129, 210, 121, 29, 243, 98, 128, 136, 144, 147, 38, 68, 208, 24
+                  ]
+                }
+              }
+            },
+            {
+              "name": "payer",
+              "writable": true,
+              "signer": true
+            },
+            {
+              "name": "clock",
+              "address": "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              "name": "rent",
+              "address": "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_program",
+              "docs": ["Wormhole program."],
+              "address": "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              "name": "system_program",
+              "address": "11111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_post_message_shim",
+              "address": "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              "name": "wormhole_post_message_shim_ea",
+              "docs": [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "data",
+          "type": {
+            "defined": {
+              "name": "SignedPayload",
+              "generics": [
+                {
+                  "kind": "type",
+                  "type": {
+                    "defined": {
+                      "name": "FinalizeTransferPayload"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "finalize_transfer_sol",
+      "discriminator": [104, 27, 121, 69, 3, 70, 217, 66],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "used_nonces",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              }
+            ]
+          }
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 111, 108, 95, 118, 97, 117, 108, 116]
+              }
+            ]
+          }
+        },
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "docs": ["Used as an emitter"],
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [99, 111, 110, 102, 105, 103]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "bridge",
+              "docs": [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [66, 114, 105, 100, 103, 101]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "fee_collector",
+              "docs": [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sequence",
+              "docs": [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "message",
+              "docs": [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ],
+                "program": {
+                  "kind": "const",
+                  "value": [
+                    206, 93, 34, 116, 131, 143, 202, 41, 198, 209, 143, 152, 10, 211, 213, 245, 235,
+                    78, 129, 210, 121, 29, 243, 98, 128, 136, 144, 147, 38, 68, 208, 24
+                  ]
+                }
+              }
+            },
+            {
+              "name": "payer",
+              "writable": true,
+              "signer": true
+            },
+            {
+              "name": "clock",
+              "address": "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              "name": "rent",
+              "address": "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_program",
+              "docs": ["Wormhole program."],
+              "address": "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              "name": "system_program",
+              "address": "11111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_post_message_shim",
+              "address": "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              "name": "wormhole_post_message_shim_ea",
+              "docs": [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "data",
+          "type": {
+            "defined": {
+              "name": "SignedPayload",
+              "generics": [
+                {
+                  "kind": "type",
+                  "type": {
+                    "defined": {
+                      "name": "FinalizeTransferPayload"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "get_version",
+      "discriminator": [168, 85, 244, 45, 81, 56, 130, 50],
+      "accounts": [],
+      "args": [],
+      "returns": "string"
+    },
+    {
+      "name": "init_transfer",
+      "discriminator": [174, 50, 134, 99, 122, 243, 243, 224],
+      "accounts": [
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true
+        },
+        {
+          "name": "from",
+          "writable": true
+        },
+        {
+          "name": "vault",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 111, 108, 95, 118, 97, 117, 108, 116]
+              }
+            ]
+          }
+        },
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "docs": ["Used as an emitter"],
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [99, 111, 110, 102, 105, 103]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "bridge",
+              "docs": [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [66, 114, 105, 100, 103, 101]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "fee_collector",
+              "docs": [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sequence",
+              "docs": [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "message",
+              "docs": [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ],
+                "program": {
+                  "kind": "const",
+                  "value": [
+                    206, 93, 34, 116, 131, 143, 202, 41, 198, 209, 143, 152, 10, 211, 213, 245, 235,
+                    78, 129, 210, 121, 29, 243, 98, 128, 136, 144, 147, 38, 68, 208, 24
+                  ]
+                }
+              }
+            },
+            {
+              "name": "payer",
+              "writable": true,
+              "signer": true
+            },
+            {
+              "name": "clock",
+              "address": "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              "name": "rent",
+              "address": "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_program",
+              "docs": ["Wormhole program."],
+              "address": "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              "name": "system_program",
+              "address": "11111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_post_message_shim",
+              "address": "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              "name": "wormhole_post_message_shim_ea",
+              "docs": [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "payload",
+          "type": {
+            "defined": {
+              "name": "InitTransferPayload"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "init_transfer_sol",
+      "discriminator": [124, 167, 164, 191, 81, 140, 108, 30],
+      "accounts": [
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 111, 108, 95, 118, 97, 117, 108, 116]
+              }
+            ]
+          }
+        },
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "docs": ["Used as an emitter"],
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [99, 111, 110, 102, 105, 103]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "bridge",
+              "docs": [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [66, 114, 105, 100, 103, 101]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "fee_collector",
+              "docs": [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sequence",
+              "docs": [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "message",
+              "docs": [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ],
+                "program": {
+                  "kind": "const",
+                  "value": [
+                    206, 93, 34, 116, 131, 143, 202, 41, 198, 209, 143, 152, 10, 211, 213, 245, 235,
+                    78, 129, 210, 121, 29, 243, 98, 128, 136, 144, 147, 38, 68, 208, 24
+                  ]
+                }
+              }
+            },
+            {
+              "name": "payer",
+              "writable": true,
+              "signer": true
+            },
+            {
+              "name": "clock",
+              "address": "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              "name": "rent",
+              "address": "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_program",
+              "docs": ["Wormhole program."],
+              "address": "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              "name": "system_program",
+              "address": "11111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_post_message_shim",
+              "address": "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              "name": "wormhole_post_message_shim_ea",
+              "docs": [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim."
+              ]
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "payload",
+          "type": {
+            "defined": {
+              "name": "InitTransferPayload"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize",
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 111, 108, 95, 118, 97, 117, 108, 116]
+              }
+            ]
+          }
+        },
+        {
+          "name": "wormhole_bridge",
+          "docs": [
+            "Wormhole bridge data account (a.k.a. its config).",
+            "[`wormhole::post_message`] requires this account be mutable."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [66, 114, 105, 100, 103, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "wormhole_fee_collector",
+          "docs": [
+            "Wormhole fee collector account, which requires lamports before the",
+            "program can post a message (if there is a fee).",
+            "[`wormhole::post_message`] requires this account be mutable."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+              }
+            ]
+          }
+        },
+        {
+          "name": "wormhole_sequence",
+          "docs": [
+            "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+            "[`initialize`](crate::initialize) instruction.",
+            "[`wormhole::post_message`] requires this account be mutable."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [83, 101, 113, 117, 101, 110, 99, 101]
+              },
+              {
+                "kind": "account",
+                "path": "config"
+              }
+            ]
+          }
+        },
+        {
+          "name": "wormhole_message",
+          "docs": ["account be mutable."],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "clock",
+          "address": "SysvarC1ock11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "wormhole_program",
+          "address": "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+        },
+        {
+          "name": "program",
+          "signer": true,
+          "address": "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p"
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "pausable_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "metadata_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "derived_near_bridge_address",
+          "type": {
+            "array": ["u8", 64]
+          }
+        }
+      ]
+    },
+    {
+      "name": "log_metadata",
+      "discriminator": [168, 157, 195, 79, 96, 210, 208, 2],
+      "accounts": [
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "metadata",
+          "optional": true
+        },
+        {
+          "name": "vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "common",
+          "accounts": [
+            {
+              "name": "config",
+              "docs": ["Used as an emitter"],
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [99, 111, 110, 102, 105, 103]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "bridge",
+              "docs": [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [66, 114, 105, 100, 103, 101]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "fee_collector",
+              "docs": [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "sequence",
+              "docs": [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "const",
+                    "value": [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "message",
+              "docs": [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim."
+              ],
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "account",
+                    "path": "config"
+                  }
+                ],
+                "program": {
+                  "kind": "const",
+                  "value": [
+                    206, 93, 34, 116, 131, 143, 202, 41, 198, 209, 143, 152, 10, 211, 213, 245, 235,
+                    78, 129, 210, 121, 29, 243, 98, 128, 136, 144, 147, 38, 68, 208, 24
+                  ]
+                }
+              }
+            },
+            {
+              "name": "payer",
+              "writable": true,
+              "signer": true
+            },
+            {
+              "name": "clock",
+              "address": "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              "name": "rent",
+              "address": "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_program",
+              "docs": ["Wormhole program."],
+              "address": "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              "name": "system_program",
+              "address": "11111111111111111111111111111111"
+            },
+            {
+              "name": "wormhole_post_message_shim",
+              "address": "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              "name": "wormhole_post_message_shim_ea",
+              "docs": [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "pause",
+      "discriminator": [211, 22, 221, 251, 74, 121, 193, 47],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "set_admin",
+      "discriminator": [251, 163, 0, 52, 91, 194, 187, 92],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_metadata_admin",
+      "discriminator": [236, 77, 199, 140, 79, 255, 196, 226],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "metadata_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_pausable_admin",
+      "discriminator": [128, 59, 6, 173, 50, 0, 213, 197],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "pausable_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "unpause",
+      "discriminator": [169, 144, 4, 38, 10, 141, 188, 255],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "paused",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "update_metadata",
+      "discriminator": [170, 182, 43, 239, 97, 78, 225, 186],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [99, 111, 110, 102, 105, 103]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "metadata",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 101, 116, 97, 100, 97, 116, 97]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  11, 112, 101, 177, 227, 209, 124, 69, 56, 157, 82, 127, 107, 4, 195, 205, 88, 184,
+                  108, 115, 26, 160, 253, 181, 73, 182, 209, 188, 3, 248, 41, 70
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                11, 112, 101, 177, 227, 209, 124, 69, 56, 157, 82, 127, 107, 4, 195, 205, 88, 184,
+                108, 115, 26, 160, 253, 181, 73, 182, 209, 188, 3, 248, 41, 70
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "token_metadata_program",
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": {
+            "option": "string"
+          }
+        },
+        {
+          "name": "symbol",
+          "type": {
+            "option": "string"
+          }
+        },
+        {
+          "name": "uri",
+          "type": {
+            "option": "string"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Config",
+      "discriminator": [155, 12, 170, 224, 30, 250, 204, 130]
+    },
+    {
+      "name": "UsedNonces",
+      "discriminator": [60, 112, 18, 72, 138, 181, 100, 138]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidArgs",
+      "msg": "Invalid arguments"
+    },
+    {
+      "code": 6001,
+      "name": "SignatureVerificationFailed",
+      "msg": "Signature verification failed"
+    },
+    {
+      "code": 6002,
+      "name": "MalleableSignature",
+      "msg": "Malleable signature"
+    },
+    {
+      "code": 6003,
+      "name": "NonceAlreadyUsed",
+      "msg": "Nonce already used"
+    },
+    {
+      "code": 6004,
+      "name": "TokenMetadataNotProvided",
+      "msg": "Token metadata not provided"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidTokenMetadataAddress",
+      "msg": "Invalid token metadata address"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidBridgedToken",
+      "msg": "Invalid bridged token"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidFee",
+      "msg": "Invalid fee"
+    },
+    {
+      "code": 6008,
+      "name": "Paused",
+      "msg": "Paused"
+    },
+    {
+      "code": 6009,
+      "name": "Unauthorized",
+      "msg": "Unauthorized"
+    }
+  ],
+  "types": [
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_used_nonce",
+            "type": "u64"
+          },
+          {
+            "name": "derived_near_bridge_address",
+            "type": {
+              "array": ["u8", 64]
+            }
+          },
+          {
+            "name": "bumps",
+            "type": {
+              "defined": {
+                "name": "ConfigBumps"
+              }
+            }
+          },
+          {
+            "name": "paused",
+            "type": "u8"
+          },
+          {
+            "name": "pausable_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "metadata_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 35]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigBumps",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "u8"
+          },
+          {
+            "name": "authority",
+            "type": "u8"
+          },
+          {
+            "name": "sol_vault",
+            "type": "u8"
+          },
+          {
+            "name": "wormhole",
+            "type": {
+              "defined": {
+                "name": "WormholeBumps"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DeployTokenPayload",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token",
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "name": "decimals",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FinalizeTransferPayload",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "destination_nonce",
+            "type": "u64"
+          },
+          {
+            "name": "transfer_id",
+            "type": {
+              "defined": {
+                "name": "TransferId"
+              }
+            }
+          },
+          {
+            "name": "amount",
+            "type": "u128"
+          },
+          {
+            "name": "fee_recipient",
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitTransferPayload",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u128"
+          },
+          {
+            "name": "recipient",
+            "type": "string"
+          },
+          {
+            "name": "fee",
+            "type": "u128"
+          },
+          {
+            "name": "native_fee",
+            "type": "u64"
+          },
+          {
+            "name": "message",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedPayload",
+      "generics": [
+        {
+          "kind": "type",
+          "name": "P"
+        }
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "payload",
+            "type": {
+              "generic": "P"
+            }
+          },
+          {
+            "name": "signature",
+            "type": {
+              "array": ["u8", 65]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferId",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "origin_chain",
+            "type": "u8"
+          },
+          {
+            "name": "origin_nonce",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UsedNonces",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": []
+      }
+    },
+    {
+      "name": "WormholeBumps",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bridge",
+            "type": "u8"
+          },
+          {
+            "name": "fee_collector",
+            "type": "u8"
+          },
+          {
+            "name": "sequence",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "ALL_PAUSED",
+      "type": "u8",
+      "value": "3"
+    },
+    {
+      "name": "ALL_UNPAUSED",
+      "type": "u8",
+      "value": "0"
+    },
+    {
+      "name": "AUTHORITY_SEED",
+      "type": "bytes",
+      "value": "[97, 117, 116, 104, 111, 114, 105, 116, 121]"
+    },
+    {
+      "name": "CONFIG_SEED",
+      "type": "bytes",
+      "value": "[99, 111, 110, 102, 105, 103]"
+    },
+    {
+      "name": "FINALIZE_TRANSFER_PAUSED",
+      "type": "u8",
+      "value": "2"
+    },
+    {
+      "name": "INIT_TRANSFER_PAUSED",
+      "type": "u8",
+      "value": "1"
+    },
+    {
+      "name": "MAX_ALLOWED_DECIMALS",
+      "type": "u8",
+      "value": "9"
+    },
+    {
+      "name": "METADATA_SEED",
+      "type": "bytes",
+      "value": "[109, 101, 116, 97, 100, 97, 116, 97]"
+    },
+    {
+      "name": "SOLANA_OMNI_BRIDGE_CHAIN_ID",
+      "type": "u8",
+      "value": "2"
+    },
+    {
+      "name": "SOL_VAULT_SEED",
+      "type": "bytes",
+      "value": "[115, 111, 108, 95, 118, 97, 117, 108, 116]"
+    },
+    {
+      "name": "USED_NONCES_ACCOUNT_SIZE",
+      "type": "u32",
+      "value": "136"
+    },
+    {
+      "name": "USED_NONCES_PER_ACCOUNT",
+      "type": "u32",
+      "value": "1024"
+    },
+    {
+      "name": "USED_NONCES_SEED",
+      "type": "bytes",
+      "value": "[117, 115, 101, 100, 95, 110, 111, 110, 99, 101, 115]"
+    },
+    {
+      "name": "VAULT_SEED",
+      "type": "bytes",
+      "value": "[118, 97, 117, 108, 116]"
+    },
+    {
+      "name": "WRAPPED_MINT_SEED",
+      "type": "bytes",
+      "value": "[119, 114, 97, 112, 112, 101, 100, 95, 109, 105, 110, 116]"
+    }
+  ]
+}

--- a/src/types/solana/bridge_token_factory_shim.ts
+++ b/src/types/solana/bridge_token_factory_shim.ts
@@ -1,0 +1,2325 @@
+/**
+ * Program IDL in camelCase format in order to be used in JS/TS.
+ *
+ * Note that this is only a type helper and is not the actual IDL. The original
+ * IDL can be found at `target/idl/bridge_token_factory.json`.
+ */
+export type BridgeTokenFactory = {
+  address: "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p"
+  metadata: {
+    name: "bridgeTokenFactory"
+    version: "0.2.5"
+    spec: "0.1.0"
+    description: "Created with Anchor"
+  }
+  instructions: [
+    {
+      name: "deployToken"
+      discriminator: [144, 104, 20, 192, 18, 112, 224, 140]
+      accounts: [
+        {
+          name: "authority"
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              },
+            ]
+          }
+        },
+        {
+          name: "mint"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [119, 114, 97, 112, 112, 101, 100, 95, 109, 105, 110, 116]
+              },
+              {
+                kind: "arg"
+                path: "data.payload.token"
+              },
+            ]
+          }
+        },
+        {
+          name: "metadata"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [109, 101, 116, 97, 100, 97, 116, 97]
+              },
+              {
+                kind: "const"
+                value: [
+                  11,
+                  112,
+                  101,
+                  177,
+                  227,
+                  209,
+                  124,
+                  69,
+                  56,
+                  157,
+                  82,
+                  127,
+                  107,
+                  4,
+                  195,
+                  205,
+                  88,
+                  184,
+                  108,
+                  115,
+                  26,
+                  160,
+                  253,
+                  181,
+                  73,
+                  182,
+                  209,
+                  188,
+                  3,
+                  248,
+                  41,
+                  70,
+                ]
+              },
+              {
+                kind: "account"
+                path: "mint"
+              },
+            ]
+            program: {
+              kind: "const"
+              value: [
+                11,
+                112,
+                101,
+                177,
+                227,
+                209,
+                124,
+                69,
+                56,
+                157,
+                82,
+                127,
+                107,
+                4,
+                195,
+                205,
+                88,
+                184,
+                108,
+                115,
+                26,
+                160,
+                253,
+                181,
+                73,
+                182,
+                209,
+                188,
+                3,
+                248,
+                41,
+                70,
+              ]
+            }
+          }
+        },
+        {
+          name: "common"
+          accounts: [
+            {
+              name: "config"
+              docs: ["Used as an emitter"]
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [99, 111, 110, 102, 105, 103]
+                  },
+                ]
+              }
+            },
+            {
+              name: "bridge"
+              docs: [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [66, 114, 105, 100, 103, 101]
+                  },
+                ]
+              }
+            },
+            {
+              name: "feeCollector"
+              docs: [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  },
+                ]
+              }
+            },
+            {
+              name: "sequence"
+              docs: [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+              }
+            },
+            {
+              name: "message"
+              docs: [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+                program: {
+                  kind: "const"
+                  value: [
+                    206,
+                    93,
+                    34,
+                    116,
+                    131,
+                    143,
+                    202,
+                    41,
+                    198,
+                    209,
+                    143,
+                    152,
+                    10,
+                    211,
+                    213,
+                    245,
+                    235,
+                    78,
+                    129,
+                    210,
+                    121,
+                    29,
+                    243,
+                    98,
+                    128,
+                    136,
+                    144,
+                    147,
+                    38,
+                    68,
+                    208,
+                    24,
+                  ]
+                }
+              }
+            },
+            {
+              name: "payer"
+              writable: true
+              signer: true
+            },
+            {
+              name: "clock"
+              address: "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              name: "rent"
+              address: "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              name: "wormholeProgram"
+              docs: ["Wormhole program."]
+              address: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              name: "systemProgram"
+              address: "11111111111111111111111111111111"
+            },
+            {
+              name: "wormholePostMessageShim"
+              address: "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              name: "wormholePostMessageShimEa"
+              docs: [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim.",
+              ]
+            },
+          ]
+        },
+        {
+          name: "systemProgram"
+          address: "11111111111111111111111111111111"
+        },
+        {
+          name: "tokenProgram"
+          address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          name: "tokenMetadataProgram"
+          address: "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+      ]
+      args: [
+        {
+          name: "data"
+          type: {
+            defined: {
+              name: "signedPayload"
+              generics: [
+                {
+                  kind: "type"
+                  type: {
+                    defined: {
+                      name: "deployTokenPayload"
+                    }
+                  }
+                },
+              ]
+            }
+          }
+        },
+      ]
+    },
+    {
+      name: "finalizeTransfer"
+      discriminator: [124, 126, 103, 188, 144, 65, 135, 51]
+      accounts: [
+        {
+          name: "usedNonces"
+          writable: true
+        },
+        {
+          name: "authority"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              },
+            ]
+          }
+        },
+        {
+          name: "recipient"
+        },
+        {
+          name: "mint"
+        },
+        {
+          name: "vault"
+          writable: true
+          optional: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [118, 97, 117, 108, 116]
+              },
+              {
+                kind: "account"
+                path: "mint"
+              },
+            ]
+          }
+        },
+        {
+          name: "tokenAccount"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "account"
+                path: "recipient"
+              },
+              {
+                kind: "const"
+                value: [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169,
+                ]
+              },
+              {
+                kind: "account"
+                path: "mint"
+              },
+            ]
+            program: {
+              kind: "const"
+              value: [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89,
+              ]
+            }
+          }
+        },
+        {
+          name: "common"
+          accounts: [
+            {
+              name: "config"
+              docs: ["Used as an emitter"]
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [99, 111, 110, 102, 105, 103]
+                  },
+                ]
+              }
+            },
+            {
+              name: "bridge"
+              docs: [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [66, 114, 105, 100, 103, 101]
+                  },
+                ]
+              }
+            },
+            {
+              name: "feeCollector"
+              docs: [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  },
+                ]
+              }
+            },
+            {
+              name: "sequence"
+              docs: [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+              }
+            },
+            {
+              name: "message"
+              docs: [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+                program: {
+                  kind: "const"
+                  value: [
+                    206,
+                    93,
+                    34,
+                    116,
+                    131,
+                    143,
+                    202,
+                    41,
+                    198,
+                    209,
+                    143,
+                    152,
+                    10,
+                    211,
+                    213,
+                    245,
+                    235,
+                    78,
+                    129,
+                    210,
+                    121,
+                    29,
+                    243,
+                    98,
+                    128,
+                    136,
+                    144,
+                    147,
+                    38,
+                    68,
+                    208,
+                    24,
+                  ]
+                }
+              }
+            },
+            {
+              name: "payer"
+              writable: true
+              signer: true
+            },
+            {
+              name: "clock"
+              address: "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              name: "rent"
+              address: "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              name: "wormholeProgram"
+              docs: ["Wormhole program."]
+              address: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              name: "systemProgram"
+              address: "11111111111111111111111111111111"
+            },
+            {
+              name: "wormholePostMessageShim"
+              address: "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              name: "wormholePostMessageShimEa"
+              docs: [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim.",
+              ]
+            },
+          ]
+        },
+        {
+          name: "associatedTokenProgram"
+          address: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          name: "systemProgram"
+          address: "11111111111111111111111111111111"
+        },
+        {
+          name: "tokenProgram"
+        },
+      ]
+      args: [
+        {
+          name: "data"
+          type: {
+            defined: {
+              name: "signedPayload"
+              generics: [
+                {
+                  kind: "type"
+                  type: {
+                    defined: {
+                      name: "finalizeTransferPayload"
+                    }
+                  }
+                },
+              ]
+            }
+          }
+        },
+      ]
+    },
+    {
+      name: "finalizeTransferSol"
+      discriminator: [104, 27, 121, 69, 3, 70, 217, 66]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "usedNonces"
+          writable: true
+        },
+        {
+          name: "authority"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              },
+            ]
+          }
+        },
+        {
+          name: "recipient"
+          writable: true
+        },
+        {
+          name: "solVault"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [115, 111, 108, 95, 118, 97, 117, 108, 116]
+              },
+            ]
+          }
+        },
+        {
+          name: "common"
+          accounts: [
+            {
+              name: "config"
+              docs: ["Used as an emitter"]
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [99, 111, 110, 102, 105, 103]
+                  },
+                ]
+              }
+            },
+            {
+              name: "bridge"
+              docs: [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [66, 114, 105, 100, 103, 101]
+                  },
+                ]
+              }
+            },
+            {
+              name: "feeCollector"
+              docs: [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  },
+                ]
+              }
+            },
+            {
+              name: "sequence"
+              docs: [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+              }
+            },
+            {
+              name: "message"
+              docs: [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+                program: {
+                  kind: "const"
+                  value: [
+                    206,
+                    93,
+                    34,
+                    116,
+                    131,
+                    143,
+                    202,
+                    41,
+                    198,
+                    209,
+                    143,
+                    152,
+                    10,
+                    211,
+                    213,
+                    245,
+                    235,
+                    78,
+                    129,
+                    210,
+                    121,
+                    29,
+                    243,
+                    98,
+                    128,
+                    136,
+                    144,
+                    147,
+                    38,
+                    68,
+                    208,
+                    24,
+                  ]
+                }
+              }
+            },
+            {
+              name: "payer"
+              writable: true
+              signer: true
+            },
+            {
+              name: "clock"
+              address: "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              name: "rent"
+              address: "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              name: "wormholeProgram"
+              docs: ["Wormhole program."]
+              address: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              name: "systemProgram"
+              address: "11111111111111111111111111111111"
+            },
+            {
+              name: "wormholePostMessageShim"
+              address: "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              name: "wormholePostMessageShimEa"
+              docs: [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim.",
+              ]
+            },
+          ]
+        },
+        {
+          name: "systemProgram"
+          address: "11111111111111111111111111111111"
+        },
+      ]
+      args: [
+        {
+          name: "data"
+          type: {
+            defined: {
+              name: "signedPayload"
+              generics: [
+                {
+                  kind: "type"
+                  type: {
+                    defined: {
+                      name: "finalizeTransferPayload"
+                    }
+                  }
+                },
+              ]
+            }
+          }
+        },
+      ]
+    },
+    {
+      name: "getVersion"
+      discriminator: [168, 85, 244, 45, 81, 56, 130, 50]
+      accounts: []
+      args: []
+      returns: "string"
+    },
+    {
+      name: "initTransfer"
+      discriminator: [174, 50, 134, 99, 122, 243, 243, 224]
+      accounts: [
+        {
+          name: "authority"
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              },
+            ]
+          }
+        },
+        {
+          name: "mint"
+          writable: true
+        },
+        {
+          name: "from"
+          writable: true
+        },
+        {
+          name: "vault"
+          writable: true
+          optional: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [118, 97, 117, 108, 116]
+              },
+              {
+                kind: "account"
+                path: "mint"
+              },
+            ]
+          }
+        },
+        {
+          name: "solVault"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [115, 111, 108, 95, 118, 97, 117, 108, 116]
+              },
+            ]
+          }
+        },
+        {
+          name: "user"
+          writable: true
+          signer: true
+        },
+        {
+          name: "common"
+          accounts: [
+            {
+              name: "config"
+              docs: ["Used as an emitter"]
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [99, 111, 110, 102, 105, 103]
+                  },
+                ]
+              }
+            },
+            {
+              name: "bridge"
+              docs: [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [66, 114, 105, 100, 103, 101]
+                  },
+                ]
+              }
+            },
+            {
+              name: "feeCollector"
+              docs: [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  },
+                ]
+              }
+            },
+            {
+              name: "sequence"
+              docs: [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+              }
+            },
+            {
+              name: "message"
+              docs: [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+                program: {
+                  kind: "const"
+                  value: [
+                    206,
+                    93,
+                    34,
+                    116,
+                    131,
+                    143,
+                    202,
+                    41,
+                    198,
+                    209,
+                    143,
+                    152,
+                    10,
+                    211,
+                    213,
+                    245,
+                    235,
+                    78,
+                    129,
+                    210,
+                    121,
+                    29,
+                    243,
+                    98,
+                    128,
+                    136,
+                    144,
+                    147,
+                    38,
+                    68,
+                    208,
+                    24,
+                  ]
+                }
+              }
+            },
+            {
+              name: "payer"
+              writable: true
+              signer: true
+            },
+            {
+              name: "clock"
+              address: "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              name: "rent"
+              address: "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              name: "wormholeProgram"
+              docs: ["Wormhole program."]
+              address: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              name: "systemProgram"
+              address: "11111111111111111111111111111111"
+            },
+            {
+              name: "wormholePostMessageShim"
+              address: "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              name: "wormholePostMessageShimEa"
+              docs: [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim.",
+              ]
+            },
+          ]
+        },
+        {
+          name: "tokenProgram"
+        },
+      ]
+      args: [
+        {
+          name: "payload"
+          type: {
+            defined: {
+              name: "initTransferPayload"
+            }
+          }
+        },
+      ]
+    },
+    {
+      name: "initTransferSol"
+      discriminator: [124, 167, 164, 191, 81, 140, 108, 30]
+      accounts: [
+        {
+          name: "solVault"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [115, 111, 108, 95, 118, 97, 117, 108, 116]
+              },
+            ]
+          }
+        },
+        {
+          name: "user"
+          writable: true
+          signer: true
+        },
+        {
+          name: "common"
+          accounts: [
+            {
+              name: "config"
+              docs: ["Used as an emitter"]
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [99, 111, 110, 102, 105, 103]
+                  },
+                ]
+              }
+            },
+            {
+              name: "bridge"
+              docs: [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [66, 114, 105, 100, 103, 101]
+                  },
+                ]
+              }
+            },
+            {
+              name: "feeCollector"
+              docs: [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  },
+                ]
+              }
+            },
+            {
+              name: "sequence"
+              docs: [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+              }
+            },
+            {
+              name: "message"
+              docs: [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+                program: {
+                  kind: "const"
+                  value: [
+                    206,
+                    93,
+                    34,
+                    116,
+                    131,
+                    143,
+                    202,
+                    41,
+                    198,
+                    209,
+                    143,
+                    152,
+                    10,
+                    211,
+                    213,
+                    245,
+                    235,
+                    78,
+                    129,
+                    210,
+                    121,
+                    29,
+                    243,
+                    98,
+                    128,
+                    136,
+                    144,
+                    147,
+                    38,
+                    68,
+                    208,
+                    24,
+                  ]
+                }
+              }
+            },
+            {
+              name: "payer"
+              writable: true
+              signer: true
+            },
+            {
+              name: "clock"
+              address: "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              name: "rent"
+              address: "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              name: "wormholeProgram"
+              docs: ["Wormhole program."]
+              address: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              name: "systemProgram"
+              address: "11111111111111111111111111111111"
+            },
+            {
+              name: "wormholePostMessageShim"
+              address: "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              name: "wormholePostMessageShimEa"
+              docs: [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim.",
+              ]
+            },
+          ]
+        },
+      ]
+      args: [
+        {
+          name: "payload"
+          type: {
+            defined: {
+              name: "initTransferPayload"
+            }
+          }
+        },
+      ]
+    },
+    {
+      name: "initialize"
+      discriminator: [175, 175, 109, 31, 13, 152, 155, 237]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "authority"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              },
+            ]
+          }
+        },
+        {
+          name: "solVault"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [115, 111, 108, 95, 118, 97, 117, 108, 116]
+              },
+            ]
+          }
+        },
+        {
+          name: "wormholeBridge"
+          docs: [
+            "Wormhole bridge data account (a.k.a. its config).",
+            "[`wormhole::post_message`] requires this account be mutable.",
+          ]
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [66, 114, 105, 100, 103, 101]
+              },
+            ]
+          }
+        },
+        {
+          name: "wormholeFeeCollector"
+          docs: [
+            "Wormhole fee collector account, which requires lamports before the",
+            "program can post a message (if there is a fee).",
+            "[`wormhole::post_message`] requires this account be mutable.",
+          ]
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+              },
+            ]
+          }
+        },
+        {
+          name: "wormholeSequence"
+          docs: [
+            "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+            "[`initialize`](crate::initialize) instruction.",
+            "[`wormhole::post_message`] requires this account be mutable.",
+          ]
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [83, 101, 113, 117, 101, 110, 99, 101]
+              },
+              {
+                kind: "account"
+                path: "config"
+              },
+            ]
+          }
+        },
+        {
+          name: "wormholeMessage"
+          docs: ["account be mutable."]
+          writable: true
+          signer: true
+        },
+        {
+          name: "payer"
+          writable: true
+          signer: true
+        },
+        {
+          name: "clock"
+          address: "SysvarC1ock11111111111111111111111111111111"
+        },
+        {
+          name: "rent"
+          address: "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          name: "systemProgram"
+          address: "11111111111111111111111111111111"
+        },
+        {
+          name: "wormholeProgram"
+          address: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+        },
+        {
+          name: "program"
+          signer: true
+          address: "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p"
+        },
+      ]
+      args: [
+        {
+          name: "admin"
+          type: "pubkey"
+        },
+        {
+          name: "pausableAdmin"
+          type: "pubkey"
+        },
+        {
+          name: "metadataAdmin"
+          type: "pubkey"
+        },
+        {
+          name: "derivedNearBridgeAddress"
+          type: {
+            array: ["u8", 64]
+          }
+        },
+      ]
+    },
+    {
+      name: "logMetadata"
+      discriminator: [168, 157, 195, 79, 96, 210, 208, 2]
+      accounts: [
+        {
+          name: "authority"
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              },
+            ]
+          }
+        },
+        {
+          name: "mint"
+        },
+        {
+          name: "metadata"
+          optional: true
+        },
+        {
+          name: "vault"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [118, 97, 117, 108, 116]
+              },
+              {
+                kind: "account"
+                path: "mint"
+              },
+            ]
+          }
+        },
+        {
+          name: "common"
+          accounts: [
+            {
+              name: "config"
+              docs: ["Used as an emitter"]
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [99, 111, 110, 102, 105, 103]
+                  },
+                ]
+              }
+            },
+            {
+              name: "bridge"
+              docs: [
+                "Wormhole bridge data account (a.k.a. its config).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [66, 114, 105, 100, 103, 101]
+                  },
+                ]
+              }
+            },
+            {
+              name: "feeCollector"
+              docs: [
+                "Wormhole fee collector account, which requires lamports before the",
+                "program can post a message (if there is a fee).",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+                  },
+                ]
+              }
+            },
+            {
+              name: "sequence"
+              docs: [
+                "message is posted, so it needs to be an [`UncheckedAccount`] for the",
+                "[`initialize`](crate::initialize) instruction.",
+                "[`wormhole::post_message`] requires this account be mutable.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "const"
+                    value: [83, 101, 113, 117, 101, 110, 99, 101]
+                  },
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+              }
+            },
+            {
+              name: "message"
+              docs: [
+                "Seeds constraint added for IDL generation / convenience, it will be enforced by the shim.",
+              ]
+              writable: true
+              pda: {
+                seeds: [
+                  {
+                    kind: "account"
+                    path: "config"
+                  },
+                ]
+                program: {
+                  kind: "const"
+                  value: [
+                    206,
+                    93,
+                    34,
+                    116,
+                    131,
+                    143,
+                    202,
+                    41,
+                    198,
+                    209,
+                    143,
+                    152,
+                    10,
+                    211,
+                    213,
+                    245,
+                    235,
+                    78,
+                    129,
+                    210,
+                    121,
+                    29,
+                    243,
+                    98,
+                    128,
+                    136,
+                    144,
+                    147,
+                    38,
+                    68,
+                    208,
+                    24,
+                  ]
+                }
+              }
+            },
+            {
+              name: "payer"
+              writable: true
+              signer: true
+            },
+            {
+              name: "clock"
+              address: "SysvarC1ock11111111111111111111111111111111"
+            },
+            {
+              name: "rent"
+              address: "SysvarRent111111111111111111111111111111111"
+            },
+            {
+              name: "wormholeProgram"
+              docs: ["Wormhole program."]
+              address: "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+            },
+            {
+              name: "systemProgram"
+              address: "11111111111111111111111111111111"
+            },
+            {
+              name: "wormholePostMessageShim"
+              address: "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX"
+            },
+            {
+              name: "wormholePostMessageShimEa"
+              docs: [
+                "TODO: An address constraint could be included if this address was published to `wormhole_solana_consts`",
+                "Address will be enforced by the shim.",
+              ]
+            },
+          ]
+        },
+        {
+          name: "systemProgram"
+          address: "11111111111111111111111111111111"
+        },
+        {
+          name: "tokenProgram"
+        },
+        {
+          name: "associatedTokenProgram"
+          address: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+      ]
+      args: []
+    },
+    {
+      name: "pause"
+      discriminator: [211, 22, 221, 251, 74, 121, 193, 47]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: []
+    },
+    {
+      name: "setAdmin"
+      discriminator: [251, 163, 0, 52, 91, 194, 187, 92]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: [
+        {
+          name: "admin"
+          type: "pubkey"
+        },
+      ]
+    },
+    {
+      name: "setMetadataAdmin"
+      discriminator: [236, 77, 199, 140, 79, 255, 196, 226]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: [
+        {
+          name: "metadataAdmin"
+          type: "pubkey"
+        },
+      ]
+    },
+    {
+      name: "setPausableAdmin"
+      discriminator: [128, 59, 6, 173, 50, 0, 213, 197]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: [
+        {
+          name: "pausableAdmin"
+          type: "pubkey"
+        },
+      ]
+    },
+    {
+      name: "unpause"
+      discriminator: [169, 144, 4, 38, 10, 141, 188, 255]
+      accounts: [
+        {
+          name: "config"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: [
+        {
+          name: "paused"
+          type: "u8"
+        },
+      ]
+    },
+    {
+      name: "updateMetadata"
+      discriminator: [170, 182, 43, 239, 97, 78, 225, 186]
+      accounts: [
+        {
+          name: "config"
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [99, 111, 110, 102, 105, 103]
+              },
+            ]
+          }
+        },
+        {
+          name: "authority"
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [97, 117, 116, 104, 111, 114, 105, 116, 121]
+              },
+            ]
+          }
+        },
+        {
+          name: "mint"
+        },
+        {
+          name: "metadata"
+          writable: true
+          pda: {
+            seeds: [
+              {
+                kind: "const"
+                value: [109, 101, 116, 97, 100, 97, 116, 97]
+              },
+              {
+                kind: "const"
+                value: [
+                  11,
+                  112,
+                  101,
+                  177,
+                  227,
+                  209,
+                  124,
+                  69,
+                  56,
+                  157,
+                  82,
+                  127,
+                  107,
+                  4,
+                  195,
+                  205,
+                  88,
+                  184,
+                  108,
+                  115,
+                  26,
+                  160,
+                  253,
+                  181,
+                  73,
+                  182,
+                  209,
+                  188,
+                  3,
+                  248,
+                  41,
+                  70,
+                ]
+              },
+              {
+                kind: "account"
+                path: "mint"
+              },
+            ]
+            program: {
+              kind: "const"
+              value: [
+                11,
+                112,
+                101,
+                177,
+                227,
+                209,
+                124,
+                69,
+                56,
+                157,
+                82,
+                127,
+                107,
+                4,
+                195,
+                205,
+                88,
+                184,
+                108,
+                115,
+                26,
+                160,
+                253,
+                181,
+                73,
+                182,
+                209,
+                188,
+                3,
+                248,
+                41,
+                70,
+              ]
+            }
+          }
+        },
+        {
+          name: "tokenProgram"
+        },
+        {
+          name: "tokenMetadataProgram"
+          address: "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+        {
+          name: "signer"
+          writable: true
+          signer: true
+        },
+      ]
+      args: [
+        {
+          name: "name"
+          type: {
+            option: "string"
+          }
+        },
+        {
+          name: "symbol"
+          type: {
+            option: "string"
+          }
+        },
+        {
+          name: "uri"
+          type: {
+            option: "string"
+          }
+        },
+      ]
+    },
+  ]
+  accounts: [
+    {
+      name: "config"
+      discriminator: [155, 12, 170, 224, 30, 250, 204, 130]
+    },
+    {
+      name: "usedNonces"
+      discriminator: [60, 112, 18, 72, 138, 181, 100, 138]
+    },
+  ]
+  errors: [
+    {
+      code: 6000
+      name: "invalidArgs"
+      msg: "Invalid arguments"
+    },
+    {
+      code: 6001
+      name: "signatureVerificationFailed"
+      msg: "Signature verification failed"
+    },
+    {
+      code: 6002
+      name: "malleableSignature"
+      msg: "Malleable signature"
+    },
+    {
+      code: 6003
+      name: "nonceAlreadyUsed"
+      msg: "Nonce already used"
+    },
+    {
+      code: 6004
+      name: "tokenMetadataNotProvided"
+      msg: "Token metadata not provided"
+    },
+    {
+      code: 6005
+      name: "invalidTokenMetadataAddress"
+      msg: "Invalid token metadata address"
+    },
+    {
+      code: 6006
+      name: "invalidBridgedToken"
+      msg: "Invalid bridged token"
+    },
+    {
+      code: 6007
+      name: "invalidFee"
+      msg: "Invalid fee"
+    },
+    {
+      code: 6008
+      name: "paused"
+      msg: "paused"
+    },
+    {
+      code: 6009
+      name: "unauthorized"
+      msg: "unauthorized"
+    },
+  ]
+  types: [
+    {
+      name: "config"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "admin"
+            type: "pubkey"
+          },
+          {
+            name: "maxUsedNonce"
+            type: "u64"
+          },
+          {
+            name: "derivedNearBridgeAddress"
+            type: {
+              array: ["u8", 64]
+            }
+          },
+          {
+            name: "bumps"
+            type: {
+              defined: {
+                name: "configBumps"
+              }
+            }
+          },
+          {
+            name: "paused"
+            type: "u8"
+          },
+          {
+            name: "pausableAdmin"
+            type: "pubkey"
+          },
+          {
+            name: "metadataAdmin"
+            type: "pubkey"
+          },
+          {
+            name: "padding"
+            type: {
+              array: ["u8", 35]
+            }
+          },
+        ]
+      }
+    },
+    {
+      name: "configBumps"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "config"
+            type: "u8"
+          },
+          {
+            name: "authority"
+            type: "u8"
+          },
+          {
+            name: "solVault"
+            type: "u8"
+          },
+          {
+            name: "wormhole"
+            type: {
+              defined: {
+                name: "wormholeBumps"
+              }
+            }
+          },
+        ]
+      }
+    },
+    {
+      name: "deployTokenPayload"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "token"
+            type: "string"
+          },
+          {
+            name: "name"
+            type: "string"
+          },
+          {
+            name: "symbol"
+            type: "string"
+          },
+          {
+            name: "decimals"
+            type: "u8"
+          },
+        ]
+      }
+    },
+    {
+      name: "finalizeTransferPayload"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "destinationNonce"
+            type: "u64"
+          },
+          {
+            name: "transferId"
+            type: {
+              defined: {
+                name: "transferId"
+              }
+            }
+          },
+          {
+            name: "amount"
+            type: "u128"
+          },
+          {
+            name: "feeRecipient"
+            type: {
+              option: "string"
+            }
+          },
+        ]
+      }
+    },
+    {
+      name: "initTransferPayload"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "amount"
+            type: "u128"
+          },
+          {
+            name: "recipient"
+            type: "string"
+          },
+          {
+            name: "fee"
+            type: "u128"
+          },
+          {
+            name: "nativeFee"
+            type: "u64"
+          },
+          {
+            name: "message"
+            type: "string"
+          },
+        ]
+      }
+    },
+    {
+      name: "signedPayload"
+      generics: [
+        {
+          kind: "type"
+          name: "p"
+        },
+      ]
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "payload"
+            type: {
+              generic: "p"
+            }
+          },
+          {
+            name: "signature"
+            type: {
+              array: ["u8", 65]
+            }
+          },
+        ]
+      }
+    },
+    {
+      name: "transferId"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "originChain"
+            type: "u8"
+          },
+          {
+            name: "originNonce"
+            type: "u64"
+          },
+        ]
+      }
+    },
+    {
+      name: "usedNonces"
+      serialization: "bytemuckunsafe"
+      repr: {
+        kind: "c"
+      }
+      type: {
+        kind: "struct"
+        fields: []
+      }
+    },
+    {
+      name: "wormholeBumps"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "bridge"
+            type: "u8"
+          },
+          {
+            name: "feeCollector"
+            type: "u8"
+          },
+          {
+            name: "sequence"
+            type: "u8"
+          },
+        ]
+      }
+    },
+  ]
+  constants: [
+    {
+      name: "allPaused"
+      type: "u8"
+      value: "3"
+    },
+    {
+      name: "allUnpaused"
+      type: "u8"
+      value: "0"
+    },
+    {
+      name: "authoritySeed"
+      type: "bytes"
+      value: "[97, 117, 116, 104, 111, 114, 105, 116, 121]"
+    },
+    {
+      name: "configSeed"
+      type: "bytes"
+      value: "[99, 111, 110, 102, 105, 103]"
+    },
+    {
+      name: "finalizeTransferPaused"
+      type: "u8"
+      value: "2"
+    },
+    {
+      name: "initTransferPaused"
+      type: "u8"
+      value: "1"
+    },
+    {
+      name: "maxAllowedDecimals"
+      type: "u8"
+      value: "9"
+    },
+    {
+      name: "metadataSeed"
+      type: "bytes"
+      value: "[109, 101, 116, 97, 100, 97, 116, 97]"
+    },
+    {
+      name: "solanaOmniBridgeChainId"
+      type: "u8"
+      value: "2"
+    },
+    {
+      name: "solVaultSeed"
+      type: "bytes"
+      value: "[115, 111, 108, 95, 118, 97, 117, 108, 116]"
+    },
+    {
+      name: "usedNoncesAccountSize"
+      type: "u32"
+      value: "136"
+    },
+    {
+      name: "usedNoncesPerAccount"
+      type: "u32"
+      value: "1024"
+    },
+    {
+      name: "usedNoncesSeed"
+      type: "bytes"
+      value: "[117, 115, 101, 100, 95, 110, 111, 110, 99, 101, 115]"
+    },
+    {
+      name: "vaultSeed"
+      type: "bytes"
+      value: "[118, 97, 117, 108, 116]"
+    },
+    {
+      name: "wrappedMintSeed"
+      type: "bytes"
+      value: "[119, 114, 97, 112, 112, 101, 100, 95, 109, 105, 110, 116]"
+    },
+  ]
+}

--- a/src/types/solana/wormhole_post_message_shim.json
+++ b/src/types/solana/wormhole_post_message_shim.json
@@ -1,0 +1,244 @@
+{
+  "address": "EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdEX",
+  "metadata": {
+    "name": "wormhole_post_message_shim",
+    "version": "0.0.0",
+    "spec": "0.1.0",
+    "description": "Anchor Interface for Wormhole Post Message Shim"
+  },
+  "instructions": [
+    {
+      "name": "post_message",
+      "docs": [
+        "This instruction is intended to be a significantly cheaper alternative",
+        "to the post message instruction on Wormhole Core Bridge program. It",
+        "achieves this by reusing the message account (per emitter) via the post",
+        "message unreliable instruction and emitting data via self-CPI (Anchor",
+        "event) for the guardian to observe. This instruction data contains",
+        "information previously found only in the resulting message account.",
+        "",
+        "Because this instruction passes through the emitter and calls the post",
+        "message unreliable instruction on the Wormhole Core Bridge, it can be",
+        "used without disruption.",
+        "",
+        "NOTE: In the initial message publication for a new emitter, this will",
+        "require one additional CPI call depth when compared to using the",
+        "Wormhole Core Bridge directly. If this initial call depth is an issue,",
+        "emit an empty message on initialization (or migration) in order to",
+        "instantiate the message account. Posting a message will result in a VAA",
+        "from your emitter, so be careful to avoid any issues that may result",
+        "from this first message.",
+        "",
+        "Call depth of direct case:",
+        "1. post message (Wormhole Post Message Shim)",
+        "2. multiple CPI",
+        "- post message unreliable (Wormhole Core Bridge)",
+        "- Anchor event of `MesssageEvent` (Wormhole Post Message Shim)",
+        "",
+        "Call depth of integrator case:",
+        "1. integrator instruction",
+        "2. CPI post message (Wormhole Post Message Shim)",
+        "3. multiple CPI",
+        "- post message unreliable (Wormhole Core Bridge)",
+        "- Anchor event of `MesssageEvent` (Wormhole Post Message Shim)"
+      ],
+      "discriminator": [214, 50, 100, 209, 38, 34, 7, 76],
+      "accounts": [
+        {
+          "name": "bridge",
+          "docs": [
+            "Wormhole Core Bridge config. The Wormhole Core Bridge program's post",
+            "message instruction requires this account to be mutable."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [66, 114, 105, 100, 103, 101]
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "wormhole_program"
+            }
+          }
+        },
+        {
+          "name": "message",
+          "docs": [
+            "Wormhole Message. The Wormhole Core Bridge program's post message",
+            "instruction requires this account to be a mutable signer.",
+            "",
+            "This program uses a PDA per emitter. Messages are already bottle-necked",
+            "by emitter sequence and the Wormhole Core Bridge program enforces that",
+            "emitter must be identical for reused accounts. While this could be",
+            "managed by the integrator, it seems more effective to have this Shim",
+            "program manage these accounts."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "emitter"
+              }
+            ]
+          }
+        },
+        {
+          "name": "emitter",
+          "docs": [
+            "Emitter of the Wormhole Core Bridge message. Wormhole Core Bridge",
+            "program's post message instruction requires this account to be a signer."
+          ],
+          "signer": true
+        },
+        {
+          "name": "sequence",
+          "docs": [
+            "Emitter's sequence account. Wormhole Core Bridge program's post message",
+            "instruction requires this account to be mutable."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [83, 101, 113, 117, 101, 110, 99, 101]
+              },
+              {
+                "kind": "account",
+                "path": "emitter"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "wormhole_program"
+            }
+          }
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Payer will pay the rent for the Wormhole Core Bridge emitter sequence",
+            "and message on the first post message call. Subsequent calls will not",
+            "require more lamports for rent."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_collector",
+          "docs": [
+            "Wormhole Core Bridge fee collector. Wormhole Core Bridge program's post",
+            "message instruction requires this account to be mutable."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 99, 111, 108, 108, 101, 99, 116, 111, 114]
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "wormhole_program"
+            }
+          }
+        },
+        {
+          "name": "clock",
+          "docs": ["Clock sysvar."],
+          "address": "SysvarC1ock11111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "docs": ["System program."],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "wormhole_program",
+          "docs": ["Wormhole Core Bridge program."]
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u32"
+        },
+        {
+          "name": "consistency_level",
+          "type": {
+            "defined": {
+              "name": "Finality"
+            }
+          }
+        },
+        {
+          "name": "payload",
+          "type": "bytes"
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "MessageEvent",
+      "discriminator": [68, 27, 143, 0, 77, 76, 137, 112]
+    }
+  ],
+  "types": [
+    {
+      "name": "Finality",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Confirmed"
+          },
+          {
+            "name": "Finalized"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MessageEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "emitter",
+            "type": "pubkey"
+          },
+          {
+            "name": "sequence",
+            "type": "u64"
+          },
+          {
+            "name": "submission_time",
+            "type": "u32"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Implements wormhole post message shim support for cost-optimized Solana bridge operations with automatic version detection and backward compatibility.

## Core Features Implemented

**Version Detection System**
- `getVersion()` method using transaction simulation
- Automatic fallback to "0.2.4" for legacy programs
- Cached version detection for performance

**Dual Program Support**
- Legacy IDL for backward compatibility
- Shim IDL for new cost-optimized functionality
- Automatic routing based on version detection

**Message Account Optimization**
- **Legacy**: Generated keypair (requires additional signer)
- **Shim**: PDA-derived from config (no additional signers, reusable)

**Updated Account Structure**
All shim methods include required additional accounts:
- `wormholePostMessageShim`
- `wormholePostMessageShimEa`

**Complete Method Coverage**
- `logMetadata()` / `logMetadataWithShim()`
- `deployToken()` / `deployTokenWithShim()`
- `initTransfer()` / `initTransferWithShim()`