### PR TITLE
feat: add BNB Chain support

### DIFF
--- a/.changeset/bnb-support.md
+++ b/.changeset/bnb-support.md
@@ -1,0 +1,11 @@
+---
+"omni-bridge-sdk": minor
+---
+
+Add BNB Chain support as EVM-compatible blockchain
+
+- Add ChainKind.Bnb enum value and BNB chain configuration
+- Support bnb: OmniAddress format with mainnet/testnet contract addresses
+- Enable BNB transfers through existing EvmBridgeClient with proper gas limits
+- Add BNB token pattern recognition for NEAR bridge tokens
+- Include comprehensive test coverage for BNB chain utilities and types

--- a/.changeset/e2e-test-infrastructure.md
+++ b/.changeset/e2e-test-infrastructure.md
@@ -1,5 +1,5 @@
 ---
-"@near-js/bridge-sdk": minor
+"omni-bridge-sdk": minor
 ---
 
 Add comprehensive E2E test infrastructure with manual cross-chain transfer flows

--- a/src/clients/evm.ts
+++ b/src/clients/evm.ts
@@ -30,11 +30,13 @@ const GAS_LIMIT = {
     [ChainKind.Eth]: 500000,
     [ChainKind.Base]: 500000,
     [ChainKind.Arb]: 3000000, // Arbitrum typically needs higher gas limits
+    [ChainKind.Bnb]: 500000,
   },
   LOG_METADATA: {
     [ChainKind.Eth]: 100000,
     [ChainKind.Base]: 100000,
     [ChainKind.Arb]: 600000,
+    [ChainKind.Bnb]: 100000,
   },
 } as const
 
@@ -65,6 +67,9 @@ export class EvmBridgeClient {
         break
       case ChainKind.Arb:
         bridgeAddress = addresses.arb
+        break
+      case ChainKind.Bnb:
+        bridgeAddress = addresses.bnb
         break
       default:
         throw new Error(`Factory address not configured for chain ${chain}`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ const ADDRESSES = {
   mainnet: {
     arb: "0xd025b38762B4A4E36F0Cde483b86CB13ea00D989",
     base: "0xd025b38762B4A4E36F0Cde483b86CB13ea00D989",
+    bnb: "0x073C8a225c8Cf9d3f9157F5C1a1DbE02407f5720",
     eth: "0xe00c629afaccb0510995a2b95560e446a24c85b9",
     near: "omni.bridge.near",
     sol: {
@@ -16,6 +17,7 @@ const ADDRESSES = {
   testnet: {
     arb: "0x0C981337fFe39a555d3A40dbb32f21aD0eF33FFA",
     base: "0xa56b860017152cD296ad723E8409Abd6e5D86d4d",
+    bnb: "0x7Fd1E9F9ed48ebb64476ba9E06e5F1a90e31DA74",
     eth: "0x68a86e0Ea5B1d39F385c1326e4d493526dFe4401",
     near: "omni.n-bridge.testnet",
     sol: {
@@ -43,6 +45,9 @@ export const addresses = {
   },
   get base() {
     return ADDRESSES[selectedNetwork].base
+  },
+  get bnb() {
+    return ADDRESSES[selectedNetwork].bnb
   },
   get eth() {
     return ADDRESSES[selectedNetwork].eth

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -14,6 +14,7 @@ type ClientTypes = {
   [ChainKind.Eth]: EvmBridgeClient
   [ChainKind.Base]: EvmBridgeClient
   [ChainKind.Arb]: EvmBridgeClient
+  [ChainKind.Bnb]: EvmBridgeClient
   [ChainKind.Sol]: SolanaBridgeClient
   [ChainKind.Btc]: never // Bitcoin client not implemented yet
 }
@@ -24,6 +25,7 @@ type WalletTypes = {
   [ChainKind.Eth]: ethers.Signer
   [ChainKind.Base]: ethers.Signer
   [ChainKind.Arb]: ethers.Signer
+  [ChainKind.Bnb]: ethers.Signer
   [ChainKind.Sol]: Provider
   [ChainKind.Btc]: never // Bitcoin wallet not implemented yet
 }
@@ -95,6 +97,7 @@ export function getClient(
 export function getClient(chain: ChainKind.Eth, wallet: ethers.Signer): EvmBridgeClient
 export function getClient(chain: ChainKind.Base, wallet: ethers.Signer): EvmBridgeClient
 export function getClient(chain: ChainKind.Arb, wallet: ethers.Signer): EvmBridgeClient
+export function getClient(chain: ChainKind.Bnb, wallet: ethers.Signer): EvmBridgeClient
 export function getClient(chain: ChainKind.Sol, wallet: Provider): SolanaBridgeClient
 
 // Generic implementation
@@ -108,6 +111,7 @@ export function getClient<T extends ChainKind>(chain: T, wallet: WalletTypes[T])
     case ChainKind.Eth:
     case ChainKind.Base:
     case ChainKind.Arb:
+    case ChainKind.Bnb:
       return new EvmBridgeClient(wallet as ethers.Signer, chain) as ClientTypes[T]
     case ChainKind.Sol:
       return new SolanaBridgeClient(wallet as Provider) as ClientTypes[T]

--- a/src/proofs/evm.ts
+++ b/src/proofs/evm.ts
@@ -36,11 +36,13 @@ const RPC_URLS: Record<"mainnet" | "testnet", Record<EVMChainKind, string>> = {
     [ChainKind.Eth]: "https://eth.llamarpc.com",
     [ChainKind.Base]: "https://mainnet.base.org",
     [ChainKind.Arb]: "https://arb1.arbitrum.io/rpc",
+    [ChainKind.Bnb]: "https://bsc-rpc.publicnode.com",
   },
   testnet: {
     [ChainKind.Eth]: "https://ethereum-sepolia.publicnode.com",
     [ChainKind.Base]: "https://sepolia.base.org",
     [ChainKind.Arb]: "https://sepolia-rollup.arbitrum.io/rpc",
+    [ChainKind.Bnb]: "https://bsc-testnet-rpc.publicnode.com",
   },
 }
 

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -6,7 +6,8 @@ export enum ChainKind {
   Sol = 2,
   Arb = 3,
   Base = 4,
-  Btc = 5,
+  Bnb = 5,
+  Btc = 6,
 }
 
 export const ChainKindSchema = b.nativeEnum(ChainKind)

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -8,3 +8,4 @@ export type OmniAddress =
   | `sol:${string}`
   | `arb:${string}`
   | `base:${string}`
+  | `bnb:${string}`

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,10 +1,10 @@
 import type { OmniAddress } from "../types/index.js"
 import { ChainKind } from "../types/index.js"
 
-type ChainPrefix = "eth" | "near" | "sol" | "arb" | "base"
+type ChainPrefix = "eth" | "near" | "sol" | "arb" | "base" | "bnb"
 
 // Type helpers for EVM chains
-export type EVMChainKind = ChainKind.Eth | ChainKind.Base | ChainKind.Arb
+export type EVMChainKind = ChainKind.Eth | ChainKind.Base | ChainKind.Arb | ChainKind.Bnb
 
 /**
  * Checks if a given chain is an EVM-compatible chain
@@ -12,7 +12,12 @@ export type EVMChainKind = ChainKind.Eth | ChainKind.Base | ChainKind.Arb
  * @returns true if the chain is EVM-compatible, false otherwise
  */
 export function isEvmChain(chain: ChainKind): chain is EVMChainKind {
-  return chain === ChainKind.Eth || chain === ChainKind.Base || chain === ChainKind.Arb
+  return (
+    chain === ChainKind.Eth ||
+    chain === ChainKind.Base ||
+    chain === ChainKind.Arb ||
+    chain === ChainKind.Bnb
+  )
 }
 
 // Helper function to construct OmniAddress
@@ -31,6 +36,7 @@ export const getChain = (addr: OmniAddress): ChainKind => {
     sol: ChainKind.Sol,
     arb: ChainKind.Arb,
     base: ChainKind.Base,
+    bnb: ChainKind.Bnb,
   } as const
 
   return chainMapping[prefix]

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -8,11 +8,13 @@ const CHAIN_PATTERNS: Record<string, ChainKind> = {
   "sol.omdep.near": ChainKind.Sol,
   "base.omdep.near": ChainKind.Base,
   "arb.omdep.near": ChainKind.Arb,
+  "bnb.omdep.near": ChainKind.Bnb,
   "nbtc-dev.testnet": ChainKind.Btc,
   "eth.sepolia.testnet": ChainKind.Eth,
   "sol.omnidep.testnet": ChainKind.Sol,
   "base.omnidep.testnet": ChainKind.Base,
   "arb.omnidep.testnet": ChainKind.Arb,
+  "bnb.omnidep.testnet": ChainKind.Bnb,
 }
 
 /**
@@ -47,6 +49,7 @@ export function parseOriginChain(nearAddress: string): ChainKind | null {
     if (nearAddress.startsWith("sol-")) return ChainKind.Sol
     if (nearAddress.startsWith("base-")) return ChainKind.Base
     if (nearAddress.startsWith("arb-")) return ChainKind.Arb
+    if (nearAddress.startsWith("bnb-")) return ChainKind.Bnb
     if (nearAddress.includes("factory.bridge")) return ChainKind.Eth
   }
 

--- a/tests/types/locker.test.ts
+++ b/tests/types/locker.test.ts
@@ -106,6 +106,7 @@ describe("Chain Kind Types", () => {
         ChainKind.Sol,
         ChainKind.Arb,
         ChainKind.Base,
+        ChainKind.Bnb,
       ]
 
       for (const chainKind of chainKinds) {

--- a/tests/utils/chain.test.ts
+++ b/tests/utils/chain.test.ts
@@ -10,6 +10,7 @@ describe("Omni Address Utils", () => {
       expect(omniAddress(ChainKind.Sol, "solana123")).toBe("sol:solana123")
       expect(omniAddress(ChainKind.Arb, "0xarb456")).toBe("arb:0xarb456")
       expect(omniAddress(ChainKind.Base, "0xbase789")).toBe("base:0xbase789")
+      expect(omniAddress(ChainKind.Bnb, "0xbnb123")).toBe("bnb:0xbnb123")
     })
 
     it("should work with empty addresses", () => {
@@ -34,9 +35,17 @@ describe("Omni Address Utils", () => {
         "sol:solana123",
         "arb:0xarb456",
         "base:0xbase789",
+        "bnb:0xbnb123",
       ]
 
-      const expected = [ChainKind.Eth, ChainKind.Near, ChainKind.Sol, ChainKind.Arb, ChainKind.Base]
+      const expected = [
+        ChainKind.Eth,
+        ChainKind.Near,
+        ChainKind.Sol,
+        ChainKind.Arb,
+        ChainKind.Base,
+        ChainKind.Bnb,
+      ]
 
       addresses.forEach((addr, i) => {
         expect(getChain(addr)).toBe(expected[i])
@@ -52,9 +61,10 @@ describe("Omni Address Utils", () => {
         "sol:solana123",
         "arb:0xarb456",
         "base:0xbase789",
+        "bnb:0xbnb123",
       ]
 
-      expect(validAddresses.length).toBe(5) // Just to use the array
+      expect(validAddresses.length).toBe(6) // Just to use the array
     })
 
     it("should allow construction via omniAddress helper", () => {
@@ -88,6 +98,7 @@ describe("Omni Address Utils", () => {
       expect(isEvmChain(ChainKind.Eth)).toBe(true)
       expect(isEvmChain(ChainKind.Arb)).toBe(true)
       expect(isEvmChain(ChainKind.Base)).toBe(true)
+      expect(isEvmChain(ChainKind.Bnb)).toBe(true)
     })
 
     it("should return false for non-EVM chains", () => {
@@ -99,7 +110,7 @@ describe("Omni Address Utils", () => {
       const chain = ChainKind.Eth
       if (isEvmChain(chain)) {
         // TypeScript should infer that chain is EVMChainKind here
-        expect([ChainKind.Eth, ChainKind.Arb, ChainKind.Base]).toContain(chain)
+        expect([ChainKind.Eth, ChainKind.Arb, ChainKind.Base, ChainKind.Bnb]).toContain(chain)
       }
     })
   })

--- a/tests/utils/tokens.test.ts
+++ b/tests/utils/tokens.test.ts
@@ -115,6 +115,7 @@ describe("Token Resolution", () => {
       expect(parseOriginChain("sol.omdep.near")).toBe(ChainKind.Sol)
       expect(parseOriginChain("base.omdep.near")).toBe(ChainKind.Base)
       expect(parseOriginChain("arb.omdep.near")).toBe(ChainKind.Arb)
+      expect(parseOriginChain("bnb.omdep.near")).toBe(ChainKind.Bnb)
     })
 
     it("returns correct chain for testnet exact matches", () => {
@@ -123,6 +124,7 @@ describe("Token Resolution", () => {
       expect(parseOriginChain("sol.omnidep.testnet")).toBe(ChainKind.Sol)
       expect(parseOriginChain("base.omnidep.testnet")).toBe(ChainKind.Base)
       expect(parseOriginChain("arb.omnidep.testnet")).toBe(ChainKind.Arb)
+      expect(parseOriginChain("bnb.omnidep.testnet")).toBe(ChainKind.Bnb)
     })
 
     it("returns correct chain for prefixed omdep.near tokens", () => {
@@ -131,6 +133,7 @@ describe("Token Resolution", () => {
       )
       expect(parseOriginChain("base-0x123456789abcdef.omdep.near")).toBe(ChainKind.Base)
       expect(parseOriginChain("arb-0xabcdef123456789.omdep.near")).toBe(ChainKind.Arb)
+      expect(parseOriginChain("bnb-0x123456789abcdef.omdep.near")).toBe(ChainKind.Bnb)
     })
 
     it("returns correct chain for prefixed omnidep.testnet tokens", () => {
@@ -143,6 +146,9 @@ describe("Token Resolution", () => {
       expect(
         parseOriginChain("arb-0x02eea354d135d1a912967c2d2a6147deb01ef92e.omnidep.testnet"),
       ).toBe(ChainKind.Arb)
+      expect(
+        parseOriginChain("bnb-0x123456789abcdef123456789abcdef1234567890.omnidep.testnet"),
+      ).toBe(ChainKind.Bnb)
     })
 
     it("returns Eth chain for factory.bridge patterns", () => {
@@ -166,6 +172,7 @@ describe("Token Resolution", () => {
       expect(parseOriginChain("sol-.omdep.near")).toBe(ChainKind.Sol)
       expect(parseOriginChain("base-.omnidep.testnet")).toBe(ChainKind.Base)
       expect(parseOriginChain("arb-.factory.bridge.near")).toBe(ChainKind.Arb)
+      expect(parseOriginChain("bnb-.omdep.near")).toBe(ChainKind.Bnb)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add BNB Chain as EVM-compatible blockchain with ChainKind.Bnb enum value
- Configure mainnet/testnet contract addresses and RPC endpoints  
- Enable BNB transfers through existing EvmBridgeClient infrastructure
- Add comprehensive test coverage for BNB utilities and types

## Test plan
- [x] Unit tests pass for chain utilities and token parsing
- [x] TypeScript compilation succeeds without errors
- [x] Linting passes with proper code formatting