### PR TITLE
Extract createBitcoinWithdrawalMessage method

### DIFF
--- a/.changeset/friendly-beers-retire.md
+++ b/.changeset/friendly-beers-retire.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+Extract createBitcoinWithdrawalMessage method


### PR DESCRIPTION
## Summary
- Separates message construction from transaction execution in Bitcoin withdrawal flow
- Enables third-party libraries to construct withdrawal messages without broadcasting transactions

## Changes
- Extracts `createBitcoinWithdrawalMessage()` method from `initBitcoinWithdrawal()`
- Returns `InitBtcTransferMsg` and total amount for external use
- Maintains existing `initBitcoinWithdrawal()` functionality