### PR TITLE
Add btc transfers flow #2

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,7 @@ const ADDRESSES = {
       network: "testnet" as const,
       apiUrl: "https://blockstream.info/testnet/api",
       mempoolUrl: "https://mempool.space/testnet/api",
-      btcConnector: "brg-dev.testnet",
+      btcConnector: "btc-connector.n-bridge.testnet",
       btcToken: "nbtc-dev.testnet",
       bitcoinRelayer: "cosmosfirst.testnet",
     },

--- a/src/types/bitcoin.ts
+++ b/src/types/bitcoin.ts
@@ -51,6 +51,7 @@ export interface InitBtcTransferMsg {
       value: number
       script_pubkey: string
     }[]
+    max_gas_fee?: bigint
   }
 }
 


### PR DESCRIPTION
- Pass message for init_transfer calls
- Add `max_gas_fee` for InitBtcTransferMsg
- Add `submitBitcoinTransfer` as an alternative way for Near->Btc transfer