### PR TITLE
Fix Solana transaction simulation type mismatch

### DIFF
--- a/src/clients/solana.ts
+++ b/src/clients/solana.ts
@@ -1,4 +1,4 @@
-import { Program, type Provider } from "@coral-xyz/anchor"
+import { Program, type Provider, web3 } from "@coral-xyz/anchor"
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_2022_PROGRAM_ID,
@@ -11,8 +11,6 @@ import {
   SYSVAR_CLOCK_PUBKEY,
   SYSVAR_RENT_PUBKEY,
   SystemProgram,
-  Transaction,
-  type TransactionInstruction,
 } from "@solana/web3.js"
 import { BN } from "bn.js"
 import { addresses } from "../config.js"
@@ -158,13 +156,13 @@ export class SolanaBridgeClient {
     }
 
     try {
-      const instruction: TransactionInstruction = {
+      const instruction = new web3.TransactionInstruction({
         keys: [],
         programId: this.program.programId,
         data: Buffer.from(GET_VERSION_DISCRIMINATOR),
-      }
+      })
 
-      const transaction = new Transaction().add(instruction)
+      const transaction = new web3.Transaction().add(instruction)
       const { blockhash } = await this.program.provider.connection.getLatestBlockhash()
       transaction.recentBlockhash = blockhash
       transaction.feePayer = this.program.provider.publicKey


### PR DESCRIPTION
## Summary
- create Solana transactions using Anchor's web3 re-export to match provider types

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e6bf8267b88329a89e0179baf7c8a7