### PR TITLE
fix: ensure NEAR RPC calls use failover provider

### DIFF
--- a/e2e/shared/setup.ts
+++ b/e2e/shared/setup.ts
@@ -2,9 +2,8 @@ import os from "node:os"
 import path from "node:path"
 import { AnchorProvider, Wallet, setProvider } from "@coral-xyz/anchor"
 import { Account } from "@near-js/accounts"
-import { getSignerFromKeystore } from "@near-js/client"
+import { createRpcClientWrapper, getSignerFromKeystore } from "@near-js/client"
 import { UnencryptedFileSystemKeyStore } from "@near-js/keystores-node"
-import { JsonRpcProvider } from "@near-js/providers"
 import { Connection, Keypair } from "@solana/web3.js"
 import { ethers } from "ethers"
 
@@ -68,14 +67,14 @@ export async function createNearAccount(): Promise<Account> {
     const keyPair = KeyPair.fromString(privateKey as any)
     await keyStore.setKey(near.networkId, near.accountId, keyPair)
     const signer = await getSignerFromKeystore(near.accountId, near.networkId, keyStore)
-    const provider = new JsonRpcProvider({ url: near.rpcUrl })
+    const provider = createRpcClientWrapper([near.rpcUrl])
     return new Account(near.accountId, provider, signer)
   }
 
   // Local development - use keystore file
   const keyStore = new UnencryptedFileSystemKeyStore(near.credentialsPath)
   const signer = await getSignerFromKeystore(near.accountId, near.networkId, keyStore)
-  const provider = new JsonRpcProvider({ url: near.rpcUrl })
+  const provider = createRpcClientWrapper([near.rpcUrl])
   return new Account(near.accountId, provider, signer)
 }
 

--- a/examples/bitcoin-deposit.ts
+++ b/examples/bitcoin-deposit.ts
@@ -18,9 +18,8 @@
 import os from "node:os"
 import path from "node:path"
 import { Account } from "@near-js/accounts"
-import { getSignerFromKeystore } from "@near-js/client"
+import { createRpcClientWrapper, getSignerFromKeystore } from "@near-js/client"
 import { UnencryptedFileSystemKeyStore } from "@near-js/keystores-node"
-import { JsonRpcProvider } from "@near-js/providers"
 import { NearBridgeClient } from "../src/clients/near.js"
 import { ChainKind } from "../src/types/chain.js"
 import type { BtcConnectorConfig } from "../src/types/bitcoin.js"
@@ -42,10 +41,8 @@ async function main() {
   // Initialize NEAR client
   const keyStore = new UnencryptedFileSystemKeyStore(path.join(os.homedir(), ".near-credentials"))
   const signer = await getSignerFromKeystore(NEAR_ACCOUNT, NETWORK, keyStore)
-  const provider = new JsonRpcProvider({
-    url: "https://rpc.testnet.near.org",
-  })
-  const account = new Account(NEAR_ACCOUNT, provider, signer)
+  const nearProvider = createRpcClientWrapper(addresses.near.rpcUrls)
+  const account = new Account(NEAR_ACCOUNT, nearProvider, signer)
 
   const bridgeClient = new NearBridgeClient(account, addresses.near.contract)
 

--- a/examples/bitcoin-withdraw.ts
+++ b/examples/bitcoin-withdraw.ts
@@ -16,9 +16,8 @@
 import os from "node:os"
 import path from "node:path"
 import { Account } from "@near-js/accounts"
-import { getSignerFromKeystore } from "@near-js/client"
+import { createRpcClientWrapper, getSignerFromKeystore } from "@near-js/client"
 import { UnencryptedFileSystemKeyStore } from "@near-js/keystores-node"
-import { JsonRpcProvider } from "@near-js/providers"
 import { NearBridgeClient } from "../src/clients/near.js"
 import { addresses, setNetwork } from "../src/config.js"
 import { ChainKind } from "../src/types/chain.js"
@@ -37,10 +36,8 @@ async function main() {
   // Initialize NEAR client
   const keyStore = new UnencryptedFileSystemKeyStore(path.join(os.homedir(), ".near-credentials"))
   const signer = await getSignerFromKeystore(NEAR_ACCOUNT, NETWORK, keyStore)
-  const provider = new JsonRpcProvider({
-    url: "https://rpc.testnet.near.org",
-  })
-  const account = new Account(NEAR_ACCOUNT, provider, signer)
+  const nearProvider = createRpcClientWrapper(addresses.near.rpcUrls)
+  const account = new Account(NEAR_ACCOUNT, nearProvider, signer)
 
   const bridgeClient = new NearBridgeClient(account, addresses.near.contract)
 

--- a/examples/zcash-deposit.ts
+++ b/examples/zcash-deposit.ts
@@ -18,9 +18,8 @@
 import os from "node:os"
 import path from "node:path"
 import { Account } from "@near-js/accounts"
-import { getSignerFromKeystore } from "@near-js/client"
+import { createRpcClientWrapper, getSignerFromKeystore } from "@near-js/client"
 import { UnencryptedFileSystemKeyStore } from "@near-js/keystores-node"
-import { JsonRpcProvider } from "@near-js/providers"
 import { NearBridgeClient } from "../src/clients/near.js"
 import { addresses, setNetwork } from "../src/config.js"
 import { ChainKind } from "../src/types/chain.js"
@@ -42,10 +41,8 @@ async function main() {
   // Initialize NEAR client
   const keyStore = new UnencryptedFileSystemKeyStore(path.join(os.homedir(), ".near-credentials"))
   const signer = await getSignerFromKeystore(NEAR_ACCOUNT, NETWORK, keyStore)
-  const provider = new JsonRpcProvider({
-    url: "https://rpc.testnet.near.org",
-  })
-  const account = new Account(NEAR_ACCOUNT, provider, signer)
+  const nearProvider = createRpcClientWrapper(addresses.near.rpcUrls)
+  const account = new Account(NEAR_ACCOUNT, nearProvider, signer)
 
   if (!ZCASH_API_KEY) {
     console.error("⚠️  Set ZCASH_API_KEY environment variable before running this script")

--- a/examples/zcash-withdraw.ts
+++ b/examples/zcash-withdraw.ts
@@ -16,9 +16,8 @@
 import os from "node:os"
 import path from "node:path"
 import { Account } from "@near-js/accounts"
-import { getSignerFromKeystore } from "@near-js/client"
+import { createRpcClientWrapper, getSignerFromKeystore } from "@near-js/client"
 import { UnencryptedFileSystemKeyStore } from "@near-js/keystores-node"
-import { JsonRpcProvider } from "@near-js/providers"
 import { NearBridgeClient } from "../src/clients/near.js"
 import { addresses, setNetwork } from "../src/config.js"
 import { ChainKind } from "../src/types/chain.js"
@@ -43,10 +42,8 @@ async function main() {
   // Initialize NEAR client
   const keyStore = new UnencryptedFileSystemKeyStore(path.join(os.homedir(), ".near-credentials"))
   const signer = await getSignerFromKeystore(NEAR_ACCOUNT, NETWORK, keyStore)
-  const provider = new JsonRpcProvider({
-    url: "https://rpc.testnet.near.org",
-  })
-  const account = new Account(NEAR_ACCOUNT, provider, signer)
+  const nearProvider = createRpcClientWrapper(addresses.near.rpcUrls)
+  const account = new Account(NEAR_ACCOUNT, nearProvider, signer)
 
   const bridgeClient = new NearBridgeClient(account, addresses.near.contract, {
     zcashApiKey: ZCASH_API_KEY,

--- a/src/clients/near-wallet-selector.ts
+++ b/src/clients/near-wallet-selector.ts
@@ -1,5 +1,4 @@
 import { callViewMethod, createRpcClientWrapper } from "@near-js/client"
-import { JsonRpcProvider } from "@near-js/providers"
 import type { FinalExecutionOutcome } from "@near-js/types"
 import type { Optional, Transaction, WalletSelector } from "@near-wallet-selector/core"
 import { addresses } from "../config.js"
@@ -641,7 +640,7 @@ export class NearWalletSelectorBridgeClient {
       const wallet = await this.selector.wallet()
       const accounts = await wallet.getAccounts()
       const accountId = accounts[0].accountId
-      const provider = new JsonRpcProvider({ url: addresses.near.rpcUrls[0] })
+      const provider = createRpcClientWrapper(addresses.near.rpcUrls)
       provider.query({
         request_type: "view_account",
         finality: "final",


### PR DESCRIPTION
## Summary
- replace direct NEAR JsonRpcProvider usage with the failover-aware wrapper in the wallet selector client
- update E2E helpers and CLI examples to initialize NEAR accounts with the failover provider

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68f150cffb6c8329997c8f4587207b90