### PR TITLE
Update API fee schema to match bridge-indexer-rs changes

### DIFF
--- a/.changeset/update-api-fee-schema.md
+++ b/.changeset/update-api-fee-schema.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+Update API client fee schema to match bridge-indexer-rs PR #255: remove relayer_fee and max_gas_fee fields, make gas_fee and protocol_fee nullable for UTXO chains

--- a/src/api.ts
+++ b/src/api.ts
@@ -99,7 +99,6 @@ const TransferMessageSchema = z.object({
   fee: z.object({
     fee: safeBigInt(),
     native_fee: safeBigInt(),
-    max_gas_fee: safeBigInt().optional(),
   }),
   msg: z.string().nullable(),
 })
@@ -148,11 +147,9 @@ const TransferSchema = z.object({
 
 const ApiFeeResponseSchema = z.object({
   native_token_fee: safeBigInt(),
-  gas_fee: safeBigInt().optional(),
-  protocol_fee: safeBigInt().optional(),
-  relayer_fee: safeBigInt().optional(),
+  gas_fee: safeBigInt(true).nullable().optional(),
+  protocol_fee: safeBigInt(true).nullable().optional(),
   usd_fee: z.number(),
-  max_gas_fee: safeBigInt(true).nullable().optional(),
   transferred_token_fee: safeBigInt(true).nullable().optional(),
 })
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -58,18 +58,14 @@ const mockFee = {
   native_token_fee: 5000,
   gas_fee: 1000,
   protocol_fee: 2000,
-  relayer_fee: 2000,
   usd_fee: 1.5,
-  max_gas_fee: null,
   transferred_token_fee: 500,
 }
 const normalizedFee = {
   native_token_fee: BigInt(5000),
   gas_fee: BigInt(1000),
   protocol_fee: BigInt(2000),
-  relayer_fee: BigInt(2000),
   usd_fee: 1.5,
-  max_gas_fee: null,
   transferred_token_fee: BigInt(500),
 }
 

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -46,14 +46,6 @@ describe("OmniBridgeAPI Integration Tests", () => {
         expect(fee.protocol_fee).toEqual(expect.any(BigInt))
         expect(fee.protocol_fee >= 0n).toBe(true)
       }
-      if (fee.relayer_fee !== undefined && fee.relayer_fee !== null) {
-        expect(fee.relayer_fee).toEqual(expect.any(BigInt))
-        expect(fee.relayer_fee >= 0n).toBe(true)
-      }
-      if (fee.max_gas_fee !== null && fee.max_gas_fee !== undefined) {
-        expect(fee.max_gas_fee).toEqual(expect.any(BigInt))
-        expect(fee.max_gas_fee >= 0n).toBe(true)
-      }
       if (fee.transferred_token_fee !== null && fee.transferred_token_fee !== undefined) {
         expect(fee.transferred_token_fee).toEqual(expect.any(BigInt))
         expect(fee.transferred_token_fee >= 0n).toBe(true)


### PR DESCRIPTION
Updates API client to match https://github.com/Near-One/bridge-indexer-rs/pull/255 fee logic changes.

## Changes

- Remove `relayer_fee` and `max_gas_fee` from `ApiFeeResponseSchema`
- Make `gas_fee` and `protocol_fee` nullable (UTXO chains only)
- Remove `max_gas_fee` from `TransferMessageSchema` fee object
- Update tests to match new schema

## Notes

- Schema is backward compatible with current API
- For UTXO transfers, `gas_fee` replaces `max_gas_fee` usage