### PR TITLE
fix: update transfer fee schema to match API response

### DIFF
--- a/.changeset/update-transfer-fee-schema.md
+++ b/.changeset/update-transfer-fee-schema.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": patch
+---
+
+Update transfer fee schema: remove max_gas_fee, add insufficient_utxo flag

--- a/src/api.ts
+++ b/src/api.ts
@@ -130,7 +130,9 @@ const TransferSchema = z.object({
   id: z
     .object({
       origin_chain: ChainSchema,
-      origin_nonce: z.number().int().min(0),
+      kind: z.object({
+        Nonce: z.number().int().min(0),
+      }),
     })
     .optional()
     .nullable(),
@@ -148,12 +150,12 @@ const TransferSchema = z.object({
 
 const ApiFeeResponseSchema = z.object({
   native_token_fee: safeBigInt(),
-  gas_fee: safeBigInt().optional(),
-  protocol_fee: safeBigInt().optional(),
-  relayer_fee: safeBigInt().optional(),
+  gas_fee: safeBigInt(true).nullable().optional(),
+  protocol_fee: safeBigInt(true).nullable().optional(),
+  relayer_fee: safeBigInt(true).nullable().optional(),
   usd_fee: z.number(),
-  max_gas_fee: safeBigInt(true).nullable().optional(),
   transferred_token_fee: safeBigInt(true).nullable().optional(),
+  insufficient_utxo: z.boolean(),
 })
 
 const AllowlistedTokensResponseSchema = z.object({

--- a/src/clients/near.ts
+++ b/src/clients/near.ts
@@ -172,7 +172,7 @@ export class NearBridgeClient {
   constructor(
     private wallet: Account,
     private lockerAddress: string = addresses.near.contract,
-    private readonly options: { zcashApiKey?: string } = {},
+    options?: { zcashApiKey?: string } | string,
   ) {
     if (lockerAddress) {
       this.lockerAddress = lockerAddress
@@ -197,11 +197,12 @@ export class NearBridgeClient {
     })
     this.utxoServices[ChainKind.Btc] = this.bitcoinService
 
-    // Initialize Zcash service if API key configured via options or environment
+    // Initialize Zcash service if API key configured via parameter or environment
+    const zcashApiKey = typeof options === "string" ? options : options?.zcashApiKey
     // biome-ignore lint/complexity/useLiteralKeys: process.env has index signature, requires bracket notation for noPropertyAccessFromIndexSignature
-    const zcashApiKey = this.options.zcashApiKey || process.env["ZCASH_API_KEY"]
-    if (zcashApiKey) {
-      this.zcashService = new ZcashService(addresses.zcash.rpcUrl, zcashApiKey)
+    const apiKey = zcashApiKey || process.env["ZCASH_API_KEY"]
+    if (apiKey) {
+      this.zcashService = new ZcashService(addresses.zcash.rpcUrl, apiKey)
       this.utxoServices[ChainKind.Zcash] = this.zcashService
     }
   }
@@ -896,7 +897,9 @@ export class NearBridgeClient {
     const recipientChain = getChain(recipientRaw)
     if (recipientChain !== ChainKind.Btc && recipientChain !== ChainKind.Zcash) {
       throw new Error(
-        `Invalid recipient chain: expected BTC or Zcash, got ${ChainKind[recipientChain] ?? recipientChain}`,
+        `Invalid recipient chain: expected BTC or Zcash, got ${
+          ChainKind[recipientChain] ?? recipientChain
+        }`,
       )
     }
 

--- a/src/services/zcash.ts
+++ b/src/services/zcash.ts
@@ -25,7 +25,6 @@ export class ZcashService {
   }
 
   private rpc: UtxoRpcClient
-
   async decodeTransaction(txHex: string) {
     const tx = await this.rpc.call("decoderawtransaction", [txHex])
     return tx

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -12,7 +12,9 @@ const BASE_URL = "https://testnet.api.bridge.nearone.org"
 const mockTransfer = {
   id: {
     origin_chain: "Eth",
-    origin_nonce: 123,
+    kind: {
+      Nonce: 123,
+    },
   },
   initialized: {
     EVMLog: {
@@ -56,21 +58,21 @@ const normalizedTransfer = {
 
 const mockFee = {
   native_token_fee: 5000,
-  gas_fee: 1000,
-  protocol_fee: 2000,
+  gas_fee: null,
+  protocol_fee: null,
   relayer_fee: 2000,
   usd_fee: 1.5,
-  max_gas_fee: null,
   transferred_token_fee: 500,
+  insufficient_utxo: false,
 }
 const normalizedFee = {
   native_token_fee: BigInt(5000),
-  gas_fee: BigInt(1000),
-  protocol_fee: BigInt(2000),
+  gas_fee: null,
+  protocol_fee: null,
   relayer_fee: BigInt(2000),
   usd_fee: 1.5,
-  max_gas_fee: null,
   transferred_token_fee: BigInt(500),
+  insufficient_utxo: false,
 }
 
 const mockAllowlistedTokens = {

--- a/tests/integration/__snapshots__/api.test.ts.snap
+++ b/tests/integration/__snapshots__/api.test.ts.snap
@@ -9,8 +9,10 @@ exports[`OmniBridgeAPI Integration Tests > findOmniTransfers > should fetch tran
     "finalised": null,
     "finalised_on_near": null,
     "id": {
+      "kind": {
+        "Nonce": 1,
+      },
       "origin_chain": "Near",
-      "origin_nonce": 1,
     },
     "initialized": {
       "NearReceipt": {
@@ -70,8 +72,10 @@ exports[`OmniBridgeAPI Integration Tests > getTransfer > should fetch transfer d
     },
     "finalised_on_near": null,
     "id": {
+      "kind": {
+        "Nonce": 22,
+      },
       "origin_chain": "Near",
-      "origin_nonce": 22,
     },
     "initialized": {
       "NearReceipt": {

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -37,7 +37,7 @@ describe("OmniBridgeAPI Integration Tests", () => {
       }
       expect(fee.usd_fee >= 0).toBe(true)
 
-      // Check optional fields if present
+      // Check optional fields if present and not null
       if (fee.gas_fee !== undefined && fee.gas_fee !== null) {
         expect(fee.gas_fee).toEqual(expect.any(BigInt))
         expect(fee.gas_fee >= 0n).toBe(true)
@@ -50,14 +50,12 @@ describe("OmniBridgeAPI Integration Tests", () => {
         expect(fee.relayer_fee).toEqual(expect.any(BigInt))
         expect(fee.relayer_fee >= 0n).toBe(true)
       }
-      if (fee.max_gas_fee !== null && fee.max_gas_fee !== undefined) {
-        expect(fee.max_gas_fee).toEqual(expect.any(BigInt))
-        expect(fee.max_gas_fee >= 0n).toBe(true)
-      }
-      if (fee.transferred_token_fee !== null && fee.transferred_token_fee !== undefined) {
+      if (fee.transferred_token_fee !== undefined && fee.transferred_token_fee !== null) {
         expect(fee.transferred_token_fee).toEqual(expect.any(BigInt))
         expect(fee.transferred_token_fee >= 0n).toBe(true)
       }
+      // Check the new insufficient_utxo field
+      expect(fee.insufficient_utxo).toEqual(expect.any(Boolean))
     })
 
     it("should handle real API errors gracefully", async () => {
@@ -171,7 +169,9 @@ describe("OmniBridgeAPI Integration Tests", () => {
         expect(transfer).toEqual({
           id: {
             origin_chain: expect.stringMatching(/^(Eth|Near|Sol|Arb|Base)$/),
-            origin_nonce: expect.any(Number),
+            kind: {
+              Nonce: expect.any(Number),
+            },
           },
           initialized: expect.any(Object),
           claimed: expect.toBeOneOf([expect.anything(), undefined, null]), // null or transaction object

--- a/tests/integration/bitcoin.test.ts
+++ b/tests/integration/bitcoin.test.ts
@@ -249,7 +249,9 @@ const server = setupServer(
     const baseTransfer = {
       id: {
         origin_chain: "Near",
-        origin_nonce: 123
+        kind: {
+          Nonce: 123
+        }
       },
       initialized: null,
       fast_finalised_on_near: null,


### PR DESCRIPTION
Removes `max_gas_fee` field and adds `insufficient_utxo` flag to match updated API response structure.

Also updates Transfer ID schema from `origin_nonce` to nested `kind: { Nonce }` format.