### PR TITLE
chore: add minor changeset for near-kit migration

### DIFF
--- a/.changeset/near-kit-migration.md
+++ b/.changeset/near-kit-migration.md
@@ -1,0 +1,5 @@
+---
+"omni-bridge-sdk": minor
+---
+
+Migrate NEAR client implementation from near-js to near-kit library. This unifies client implementations and eliminates the need for separate wallet selector clients. The new implementation provides a more modern, type-safe API with human-readable gas and deposit units.


### PR DESCRIPTION
Adds a minor changeset to properly version the near-kit migration as 0.24.0.

This ensures the breaking internal change from near-js to near-kit is properly reflected in semantic versioning. Partners requiring the pre-near-kit implementation can use v0.23.0.