### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code owners for bridge-sdk-js
+* @Near-One/devex @Near-One/bridge


### PR DESCRIPTION
## Summary
- Add CODEOWNERS file assigning @Near-One/devex and @Near-One/bridge as code owners for all files