### PR TITLE
fix(ci): enable npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - rewrite
+      - fix/trusted-publishing-oidc
     paths:
       - ".changeset/**"
       - ".github/workflows/release.yml"
@@ -25,6 +26,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
       - uses: oven-sh/setup-bun@v2
         name: Install bun
         with:
@@ -43,4 +50,3 @@ jobs:
           publish: bun run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,9 @@ on:
     branches:
       - main
       - rewrite
-      - fix/trusted-publishing-oidc
     paths:
       - ".changeset/**"
       - ".github/workflows/release.yml"
-      - "package.json"
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - rewrite
-      - fix/trusted-publishing-oidc
     paths:
       - ".changeset/**"
       - ".github/workflows/release.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,6 @@ jobs:
           publish: bun run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Empty string prevents changesets/action from writing token to .npmrc,
+          # allowing npm to use OIDC trusted publishing instead
+          NPM_TOKEN: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - main
       - rewrite
+      - fix/trusted-publishing-oidc
     paths:
       - ".changeset/**"
       - ".github/workflows/release.yml"
+      - "package.json"
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lefthook": "lefthook install",
     "check-exports": "bun run --filter '*' check-exports",
     "ci:version": "changeset version && bun update",
-    "ci:publish": "bun run build && for dir in packages/*; do (cd \"$dir\" && bun pm pack && npm publish *.tgz --access public && rm *.tgz); done && changeset tag",
+    "ci:publish": "bun run build && for dir in packages/*; do (cd \"$dir\" && PKG_NAME=$(jq -r .name package.json) && PKG_VERSION=$(jq -r .version package.json) && if npm view \"$PKG_NAME@$PKG_VERSION\" version 2>/dev/null; then echo \"$PKG_NAME@$PKG_VERSION already published, skipping\"; else bun pm pack && npm publish *.tgz --access public && rm *.tgz; fi); done && changeset tag",
     "release": "bun run ci:publish",
     "knip": "knip",
     "example:bitcoin-deposit": "bun run examples/bitcoin-deposit.ts",


### PR DESCRIPTION
## Summary
- Enable npm OIDC trusted publishing by adding Node.js 24 and setting empty NPM_TOKEN
- Fix ci:publish to skip already-published packages

## Changes
- Add `actions/setup-node@v4` with Node.js 24 (ships with npm >= 11.5.1 required for OIDC)
- Set `NPM_TOKEN: ""` to prevent changesets/action from writing token to .npmrc
- Update `ci:publish` script to check if package version exists before publishing