### PR TITLE
fix: correct repository URL case for npm provenance verification

### DIFF
--- a/packages/btc/package.json
+++ b/packages/btc/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/near-one/bridge-sdk-js",
+    "url": "https://github.com/Near-One/bridge-sdk-js",
     "directory": "packages/btc"
   },
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/near-one/bridge-sdk-js",
+    "url": "https://github.com/Near-One/bridge-sdk-js",
     "directory": "packages/core"
   },
   "license": "MIT",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/near-one/bridge-sdk-js",
+    "url": "https://github.com/Near-One/bridge-sdk-js",
     "directory": "packages/evm"
   },
   "license": "MIT",

--- a/packages/near/package.json
+++ b/packages/near/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/near-one/bridge-sdk-js",
+    "url": "https://github.com/Near-One/bridge-sdk-js",
     "directory": "packages/near"
   },
   "license": "MIT",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/near-one/bridge-sdk-js",
+    "url": "https://github.com/Near-One/bridge-sdk-js",
     "directory": "packages/sdk"
   },
   "license": "MIT",

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/near-one/bridge-sdk-js",
+    "url": "https://github.com/Near-One/bridge-sdk-js",
     "directory": "packages/solana"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary
Fix repository URL case mismatch causing npm provenance verification to fail.

## Problem
The `repository.url` in package.json files used lowercase `near-one`, but GitHub's organization name is `Near-One`. npm's sigstore provenance verification is case-sensitive, causing publish to fail with:

```
Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "git+https://github.com/near-one/bridge-sdk-js.git", 
expected to match "https://github.com/Near-One/bridge-sdk-js" from provenance
```

## Fix
Changed `near-one` → `Near-One` in all package.json repository URLs.