### PR TITLE
feat(core): add isBridgeToken and parseOriginChain utilities

### DIFF
--- a/.changeset/add-bridge-token-utils.md
+++ b/.changeset/add-bridge-token-utils.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/core": minor
+---
+
+Add `isBridgeToken` and `parseOriginChain` token utility functions for offline validation and parsing of NEAR bridge token addresses

--- a/.changeset/add-bridge-token-utils.md
+++ b/.changeset/add-bridge-token-utils.md
@@ -1,5 +1,5 @@
 ---
-"@omni-bridge/core": minor
+"@omni-bridge/core": patch
 ---
 
 Add `isBridgeToken` and `parseOriginChain` token utility functions for offline validation and parsing of NEAR bridge token addresses

--- a/README.md
+++ b/README.md
@@ -227,6 +227,29 @@ const transfers = await api.findTransfers({
 })
 ```
 
+## Token Utilities
+
+The SDK provides utilities for identifying and parsing bridge token addresses on NEAR:
+
+```typescript
+import { isBridgeToken, parseOriginChain, ChainKind } from "@omni-bridge/core"
+
+// Check if a NEAR address is a bridge token
+isBridgeToken("nbtc.bridge.near") // true - native BTC wrapper
+isBridgeToken("sol-ABC123.omdep.near") // true - wrapped SOL token
+isBridgeToken("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near") // true - bridged USDC
+isBridgeToken("wrap.near") // false - not a bridge token
+
+// Parse the origin chain from a NEAR token address (offline, no RPC)
+parseOriginChain("nbtc.bridge.near") // ChainKind.Btc
+parseOriginChain("sol-ABC123.omdep.near") // ChainKind.Sol
+parseOriginChain("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near") // ChainKind.Eth
+parseOriginChain("base-0x1234.omdep.near") // ChainKind.Base
+parseOriginChain("wrap.near") // null - not a bridge token
+```
+
+These are useful for building UIs that need to identify bridge tokens without making API calls.
+
 ## Fees and Relayers
 
 Cross-chain transfers can be finalized in two ways:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,5 +86,8 @@ export {
   verifyTransferAmount,
 } from "./utils/decimals.js"
 
+// Token utilities
+export { isBridgeToken, parseOriginChain } from "./utils/token.js"
+
 // Wormhole VAA utilities
 export { getVaa, getWormholeVaa, type WormholeNetwork } from "./wormhole.js"

--- a/packages/core/src/utils/token.ts
+++ b/packages/core/src/utils/token.ts
@@ -1,0 +1,101 @@
+/**
+ * Token utilities for identifying and parsing bridge token addresses
+ */
+
+import { ChainKind } from "../types.js"
+
+/**
+ * Known bridge token contract patterns for exact matching
+ * Maps NEAR contract addresses to their origin chain
+ */
+const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
+  // Mainnet
+  "nbtc.bridge.near": ChainKind.Btc,
+  "nzec.bridge.near": ChainKind.Zcash,
+  "eth.bridge.near": ChainKind.Eth,
+  "sol.omdep.near": ChainKind.Sol,
+  "base.omdep.near": ChainKind.Base,
+  "arb.omdep.near": ChainKind.Arb,
+  "bnb.omdep.near": ChainKind.Bnb,
+  "pol.omdep.near": ChainKind.Pol,
+  // Testnet
+  "nbtc.n-bridge.testnet": ChainKind.Btc,
+  "nzcash.n-bridge.testnet": ChainKind.Zcash,
+  "eth.sepolia.testnet": ChainKind.Eth,
+  "sol.omnidep.testnet": ChainKind.Sol,
+  "base.omnidep.testnet": ChainKind.Base,
+  "arb.omnidep.testnet": ChainKind.Arb,
+  "bnb.omnidep.testnet": ChainKind.Bnb,
+  "pol.omnidep.testnet": ChainKind.Pol,
+}
+
+/**
+ * Regex pattern matching known bridge token factory suffixes
+ */
+const BRIDGE_TOKEN_SUFFIX_PATTERN =
+  /\.(omdep\.near|omnidep\.testnet|factory\.bridge\.(near|testnet))$/
+
+/**
+ * Chain prefix patterns for wrapped tokens
+ */
+const CHAIN_PREFIXES: Record<string, ChainKind> = {
+  "sol-": ChainKind.Sol,
+  "base-": ChainKind.Base,
+  "arb-": ChainKind.Arb,
+  "bnb-": ChainKind.Bnb,
+  "pol-": ChainKind.Pol,
+}
+
+/**
+ * Validates if a NEAR address is a recognized omni bridge token
+ *
+ * @param nearAddress - The NEAR address to validate
+ * @returns true if the address follows a known omni bridge token pattern
+ *
+ * @example
+ * ```ts
+ * isBridgeToken("nbtc.bridge.near") // true - known BTC token
+ * isBridgeToken("sol-ABC123.omdep.near") // true - wrapped SOL token
+ * isBridgeToken("random.near") // false - not a bridge token
+ * isBridgeToken("foo.omdep.near") // true - matches factory suffix
+ * ```
+ */
+export function isBridgeToken(nearAddress: string): boolean {
+  return nearAddress in KNOWN_BRIDGE_TOKENS || BRIDGE_TOKEN_SUFFIX_PATTERN.test(nearAddress)
+}
+
+/**
+ * Parses the origin chain from a NEAR token address format.
+ * This is an offline parsing function that uses pattern matching
+ * without making any RPC calls.
+ *
+ * @param nearAddress - The NEAR token address
+ *   (e.g., "sol-3ZLekZYq2qkZiSpnSvabjit34tUkjSwD1JFuW9as9wBG.omdep.near")
+ * @returns The origin chain kind, or null if pattern is not recognized
+ *
+ * @example
+ * ```ts
+ * parseOriginChain("nbtc.bridge.near") // ChainKind.Btc
+ * parseOriginChain("sol-ABC123.omdep.near") // ChainKind.Sol
+ * parseOriginChain("eth.factory.bridge.near") // ChainKind.Eth
+ * parseOriginChain("random.near") // null
+ * ```
+ */
+export function parseOriginChain(nearAddress: string): ChainKind | null {
+  // Check exact matches first
+  const exactMatch = KNOWN_BRIDGE_TOKENS[nearAddress]
+  if (exactMatch !== undefined) return exactMatch
+
+  // Check if it matches a bridge token factory pattern
+  if (BRIDGE_TOKEN_SUFFIX_PATTERN.test(nearAddress)) {
+    // Check for chain prefixes
+    for (const [prefix, chain] of Object.entries(CHAIN_PREFIXES)) {
+      if (nearAddress.startsWith(prefix)) return chain
+    }
+
+    // ETH tokens use factory.bridge suffix
+    if (nearAddress.includes("factory.bridge")) return ChainKind.Eth
+  }
+
+  return null
+}

--- a/packages/core/src/utils/token.ts
+++ b/packages/core/src/utils/token.ts
@@ -12,6 +12,7 @@ const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
   // Mainnet
   "nbtc.bridge.near": ChainKind.Btc,
   "nzec.bridge.near": ChainKind.Zcash,
+  "zec.omft.near": ChainKind.Zcash,
   "eth.bridge.near": ChainKind.Eth,
   "sol.omdep.near": ChainKind.Sol,
   "base.omdep.near": ChainKind.Base,

--- a/packages/core/src/utils/token.ts
+++ b/packages/core/src/utils/token.ts
@@ -34,7 +34,7 @@ const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
  * Regex pattern matching known bridge token factory suffixes
  */
 const BRIDGE_TOKEN_SUFFIX_PATTERN =
-  /\.(omdep\.near|omnidep\.testnet|factory\.bridge\.(near|testnet))$/
+  /\.(omdep\.near|omnidep\.testnet|factory\.bridge\.near|factory\.sepolia\.testnet)$/
 
 /**
  * Chain prefix patterns for wrapped tokens
@@ -94,8 +94,9 @@ export function parseOriginChain(nearAddress: string): ChainKind | null {
       if (nearAddress.startsWith(prefix)) return chain
     }
 
-    // ETH tokens use factory.bridge suffix
-    if (nearAddress.includes("factory.bridge")) return ChainKind.Eth
+    // ETH tokens use factory.bridge (mainnet) or factory.sepolia (testnet) suffix
+    if (nearAddress.includes("factory.bridge") || nearAddress.includes("factory.sepolia"))
+      return ChainKind.Eth
   }
 
   return null

--- a/packages/core/tests/token.test.ts
+++ b/packages/core/tests/token.test.ts
@@ -7,11 +7,13 @@ describe("Token Utils", () => {
     it("should return true for known mainnet bridge tokens", () => {
       expect(isBridgeToken("nbtc.bridge.near")).toBe(true)
       expect(isBridgeToken("nzec.bridge.near")).toBe(true)
+      expect(isBridgeToken("zec.omft.near")).toBe(true)
       expect(isBridgeToken("eth.bridge.near")).toBe(true)
       expect(isBridgeToken("sol.omdep.near")).toBe(true)
       expect(isBridgeToken("base.omdep.near")).toBe(true)
       expect(isBridgeToken("arb.omdep.near")).toBe(true)
       expect(isBridgeToken("bnb.omdep.near")).toBe(true)
+      expect(isBridgeToken("pol.omdep.near")).toBe(true)
     })
 
     it("should return true for known testnet bridge tokens", () => {
@@ -45,6 +47,7 @@ describe("Token Utils", () => {
 
       it("should parse mainnet Zcash token", () => {
         expect(parseOriginChain("nzec.bridge.near")).toBe(ChainKind.Zcash)
+        expect(parseOriginChain("zec.omft.near")).toBe(ChainKind.Zcash)
       })
 
       it("should parse mainnet ETH token", () => {
@@ -65,6 +68,10 @@ describe("Token Utils", () => {
 
       it("should parse mainnet BNB token", () => {
         expect(parseOriginChain("bnb.omdep.near")).toBe(ChainKind.Bnb)
+      })
+
+      it("should parse mainnet Pol token", () => {
+        expect(parseOriginChain("pol.omdep.near")).toBe(ChainKind.Pol)
       })
 
       it("should parse testnet tokens", () => {
@@ -101,6 +108,10 @@ describe("Token Utils", () => {
       it("should parse ETH tokens from factory.bridge", () => {
         expect(parseOriginChain("usdc.factory.bridge.near")).toBe(ChainKind.Eth)
         expect(parseOriginChain("dai.factory.bridge.testnet")).toBe(ChainKind.Eth)
+        // ETH address format tokens
+        expect(
+          parseOriginChain("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near"),
+        ).toBe(ChainKind.Eth)
       })
     })
 

--- a/packages/core/tests/token.test.ts
+++ b/packages/core/tests/token.test.ts
@@ -26,8 +26,10 @@ describe("Token Utils", () => {
       expect(isBridgeToken("sol-ABC123.omdep.near")).toBe(true)
       expect(isBridgeToken("base-0x1234.omdep.near")).toBe(true)
       expect(isBridgeToken("arb-0xabcd.omnidep.testnet")).toBe(true)
-      expect(isBridgeToken("eth-token.factory.bridge.near")).toBe(true)
-      expect(isBridgeToken("usdc.factory.bridge.testnet")).toBe(true)
+      // Mainnet ETH factory
+      expect(isBridgeToken("usdc.factory.bridge.near")).toBe(true)
+      // Testnet ETH factory
+      expect(isBridgeToken("usdc.factory.sepolia.testnet")).toBe(true)
     })
 
     it("should return false for non-bridge tokens", () => {
@@ -105,12 +107,18 @@ describe("Token Utils", () => {
     })
 
     describe("factory.bridge pattern", () => {
-      it("should parse ETH tokens from factory.bridge", () => {
+      it("should parse ETH tokens from factory.bridge (mainnet)", () => {
         expect(parseOriginChain("usdc.factory.bridge.near")).toBe(ChainKind.Eth)
-        expect(parseOriginChain("dai.factory.bridge.testnet")).toBe(ChainKind.Eth)
         // ETH address format tokens
         expect(
           parseOriginChain("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near"),
+        ).toBe(ChainKind.Eth)
+      })
+
+      it("should parse ETH tokens from factory.sepolia (testnet)", () => {
+        expect(parseOriginChain("usdc.factory.sepolia.testnet")).toBe(ChainKind.Eth)
+        expect(
+          parseOriginChain("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.sepolia.testnet"),
         ).toBe(ChainKind.Eth)
       })
     })

--- a/packages/core/tests/token.test.ts
+++ b/packages/core/tests/token.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+import { ChainKind } from "../src/types.js"
+import { isBridgeToken, parseOriginChain } from "../src/utils/token.js"
+
+describe("Token Utils", () => {
+  describe("isBridgeToken", () => {
+    it("should return true for known mainnet bridge tokens", () => {
+      expect(isBridgeToken("nbtc.bridge.near")).toBe(true)
+      expect(isBridgeToken("nzec.bridge.near")).toBe(true)
+      expect(isBridgeToken("eth.bridge.near")).toBe(true)
+      expect(isBridgeToken("sol.omdep.near")).toBe(true)
+      expect(isBridgeToken("base.omdep.near")).toBe(true)
+      expect(isBridgeToken("arb.omdep.near")).toBe(true)
+      expect(isBridgeToken("bnb.omdep.near")).toBe(true)
+    })
+
+    it("should return true for known testnet bridge tokens", () => {
+      expect(isBridgeToken("nbtc.n-bridge.testnet")).toBe(true)
+      expect(isBridgeToken("sol.omnidep.testnet")).toBe(true)
+      expect(isBridgeToken("base.omnidep.testnet")).toBe(true)
+    })
+
+    it("should return true for wrapped tokens with factory suffix", () => {
+      expect(isBridgeToken("sol-ABC123.omdep.near")).toBe(true)
+      expect(isBridgeToken("base-0x1234.omdep.near")).toBe(true)
+      expect(isBridgeToken("arb-0xabcd.omnidep.testnet")).toBe(true)
+      expect(isBridgeToken("eth-token.factory.bridge.near")).toBe(true)
+      expect(isBridgeToken("usdc.factory.bridge.testnet")).toBe(true)
+    })
+
+    it("should return false for non-bridge tokens", () => {
+      expect(isBridgeToken("random.near")).toBe(false)
+      expect(isBridgeToken("alice.near")).toBe(false)
+      expect(isBridgeToken("wrap.near")).toBe(false)
+      expect(isBridgeToken("usdt.tether-token.near")).toBe(false)
+      expect(isBridgeToken("")).toBe(false)
+    })
+  })
+
+  describe("parseOriginChain", () => {
+    describe("exact matches", () => {
+      it("should parse mainnet BTC token", () => {
+        expect(parseOriginChain("nbtc.bridge.near")).toBe(ChainKind.Btc)
+      })
+
+      it("should parse mainnet Zcash token", () => {
+        expect(parseOriginChain("nzec.bridge.near")).toBe(ChainKind.Zcash)
+      })
+
+      it("should parse mainnet ETH token", () => {
+        expect(parseOriginChain("eth.bridge.near")).toBe(ChainKind.Eth)
+      })
+
+      it("should parse mainnet SOL token", () => {
+        expect(parseOriginChain("sol.omdep.near")).toBe(ChainKind.Sol)
+      })
+
+      it("should parse mainnet Base token", () => {
+        expect(parseOriginChain("base.omdep.near")).toBe(ChainKind.Base)
+      })
+
+      it("should parse mainnet Arb token", () => {
+        expect(parseOriginChain("arb.omdep.near")).toBe(ChainKind.Arb)
+      })
+
+      it("should parse mainnet BNB token", () => {
+        expect(parseOriginChain("bnb.omdep.near")).toBe(ChainKind.Bnb)
+      })
+
+      it("should parse testnet tokens", () => {
+        expect(parseOriginChain("nbtc.n-bridge.testnet")).toBe(ChainKind.Btc)
+        expect(parseOriginChain("sol.omnidep.testnet")).toBe(ChainKind.Sol)
+        expect(parseOriginChain("base.omnidep.testnet")).toBe(ChainKind.Base)
+      })
+    })
+
+    describe("prefix patterns", () => {
+      it("should parse SOL-prefixed wrapped tokens", () => {
+        expect(parseOriginChain("sol-ABC123.omdep.near")).toBe(ChainKind.Sol)
+        expect(parseOriginChain("sol-TokenMint.omnidep.testnet")).toBe(ChainKind.Sol)
+      })
+
+      it("should parse Base-prefixed wrapped tokens", () => {
+        expect(parseOriginChain("base-0x1234.omdep.near")).toBe(ChainKind.Base)
+      })
+
+      it("should parse Arb-prefixed wrapped tokens", () => {
+        expect(parseOriginChain("arb-0xabcd.omdep.near")).toBe(ChainKind.Arb)
+      })
+
+      it("should parse BNB-prefixed wrapped tokens", () => {
+        expect(parseOriginChain("bnb-0x5678.omdep.near")).toBe(ChainKind.Bnb)
+      })
+
+      it("should parse Pol-prefixed wrapped tokens", () => {
+        expect(parseOriginChain("pol-0x9999.omdep.near")).toBe(ChainKind.Pol)
+      })
+    })
+
+    describe("factory.bridge pattern", () => {
+      it("should parse ETH tokens from factory.bridge", () => {
+        expect(parseOriginChain("usdc.factory.bridge.near")).toBe(ChainKind.Eth)
+        expect(parseOriginChain("dai.factory.bridge.testnet")).toBe(ChainKind.Eth)
+      })
+    })
+
+    describe("unrecognized patterns", () => {
+      it("should return null for random NEAR accounts", () => {
+        expect(parseOriginChain("random.near")).toBeNull()
+        expect(parseOriginChain("alice.near")).toBeNull()
+      })
+
+      it("should return null for non-bridge tokens", () => {
+        expect(parseOriginChain("wrap.near")).toBeNull()
+        expect(parseOriginChain("usdt.tether-token.near")).toBeNull()
+      })
+
+      it("should return null for empty string", () => {
+        expect(parseOriginChain("")).toBeNull()
+      })
+
+      it("should return null for tokens with unknown prefix but valid suffix", () => {
+        // Has valid suffix but unknown prefix - could be a new chain or unknown token
+        expect(parseOriginChain("unknown-abc.omdep.near")).toBeNull()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `isBridgeToken(nearAddress)` - validates if a NEAR address is a recognized omni bridge token
- Add `parseOriginChain(nearAddress)` - parses the origin chain from a NEAR token address (offline, no RPC)

These functions were present in the legacy SDK and were removed during the v2 refactor. Re-adding them as they provide useful offline utilities for identifying bridge tokens without API calls.

## Usage

```ts
import { isBridgeToken, parseOriginChain, ChainKind } from "@omni-bridge/core"

isBridgeToken("nbtc.bridge.near") // true
isBridgeToken("sol-ABC123.omdep.near") // true
isBridgeToken("random.near") // false

parseOriginChain("nbtc.bridge.near") // ChainKind.Btc
parseOriginChain("sol-ABC123.omdep.near") // ChainKind.Sol
parseOriginChain("random.near") // null
```