### PR TITLE
feat(core): add isBridgeToken/parseOriginChain utilities and fix custom RPC URL support

### DIFF
--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -162,7 +162,12 @@ class BridgeImpl implements Bridge {
     this.network = config.network
     this.addresses = getAddresses(config.network)
     this.api = new BridgeAPI(config.network)
-    this.near = new Near({ network: config.network })
+
+    // Use custom NEAR RPC URL if provided, otherwise use default network config
+    const nearRpcUrl = config.rpcUrls?.[ChainKind.Near]
+    this.near = nearRpcUrl
+      ? new Near({ rpcUrl: nearRpcUrl, network: config.network })
+      : new Near({ network: config.network })
   }
 
   async validateTransfer(params: TransferParams): Promise<ValidatedTransfer> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,7 +77,8 @@ export {
   isEvmChain,
   omniAddress,
 } from "./utils/address.js"
-
+// Bridge token utilities
+export { isBridgeToken, parseOriginChain } from "./utils/bridge-token.js"
 // Decimal utilities
 export {
   getMinimumTransferableAmount,

--- a/packages/core/src/utils/bridge-token.ts
+++ b/packages/core/src/utils/bridge-token.ts
@@ -1,0 +1,135 @@
+/**
+ * Utilities for identifying and parsing omni bridge tokens on NEAR
+ */
+
+import { ChainKind } from "../types.js"
+
+/**
+ * Known bridge token suffixes for mainnet and testnet.
+ * These are the NEAR account suffixes used by the omni bridge.
+ */
+const BRIDGE_TOKEN_SUFFIXES = [".bridge.near", ".n-bridge.testnet", ".omni-bridge.testnet"]
+
+/**
+ * Known bridge token prefixes and their corresponding chain kinds.
+ * These are used by the omni bridge deployer contract.
+ */
+const BRIDGE_TOKEN_PREFIXES: Record<string, ChainKind> = {
+  "eth-": ChainKind.Eth,
+  "arb-": ChainKind.Arb,
+  "base-": ChainKind.Base,
+  "bnb-": ChainKind.Bnb,
+  "sol-": ChainKind.Sol,
+  "pol-": ChainKind.Pol,
+}
+
+/**
+ * Special native wrapped tokens and their chain kinds
+ */
+const NATIVE_BRIDGE_TOKENS: Record<string, ChainKind> = {
+  // Mainnet
+  "nbtc.bridge.near": ChainKind.Btc,
+  "nzec.bridge.near": ChainKind.Zcash,
+  // Testnet
+  "nbtc.n-bridge.testnet": ChainKind.Btc,
+  "nzcash.n-bridge.testnet": ChainKind.Zcash,
+}
+
+/**
+ * Deployer account patterns that contain bridge tokens
+ */
+const DEPLOYER_PATTERNS = [
+  ".omdep.near",
+  ".omdeployer.testnet",
+  ".bridge.near",
+  ".n-bridge.testnet",
+]
+
+/**
+ * Check if a NEAR address is a recognized omni bridge token.
+ *
+ * This performs offline validation without any RPC calls.
+ *
+ * @param nearAddress - The NEAR account address to check
+ * @returns true if the address matches known bridge token patterns
+ *
+ * @example
+ * ```ts
+ * isBridgeToken("nbtc.bridge.near") // true
+ * isBridgeToken("sol-ABC123.omdep.near") // true
+ * isBridgeToken("random.near") // false
+ * ```
+ */
+export function isBridgeToken(nearAddress: string): boolean {
+  // Check native bridge tokens first
+  if (NATIVE_BRIDGE_TOKENS[nearAddress]) {
+    return true
+  }
+
+  // Check if it's a deployed bridge token (has chain prefix)
+  for (const suffix of DEPLOYER_PATTERNS) {
+    if (nearAddress.endsWith(suffix)) {
+      const accountName = nearAddress.slice(0, -suffix.length)
+      // Check if it starts with a known chain prefix
+      for (const prefix of Object.keys(BRIDGE_TOKEN_PREFIXES)) {
+        if (accountName.startsWith(prefix) || accountName.includes(`.${prefix.slice(0, -1)}-`)) {
+          return true
+        }
+      }
+    }
+  }
+
+  // Check generic bridge token suffixes
+  for (const suffix of BRIDGE_TOKEN_SUFFIXES) {
+    if (nearAddress.endsWith(suffix)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Parse the origin chain from a NEAR bridge token address.
+ *
+ * This performs offline parsing without any RPC calls.
+ *
+ * @param nearAddress - The NEAR account address of a bridge token
+ * @returns The origin ChainKind, or null if not a recognized bridge token
+ *
+ * @example
+ * ```ts
+ * parseOriginChain("nbtc.bridge.near") // ChainKind.Btc
+ * parseOriginChain("sol-ABC123.omdep.near") // ChainKind.Sol
+ * parseOriginChain("random.near") // null
+ * ```
+ */
+export function parseOriginChain(nearAddress: string): ChainKind | null {
+  // Check native bridge tokens first
+  if (NATIVE_BRIDGE_TOKENS[nearAddress] !== undefined) {
+    return NATIVE_BRIDGE_TOKENS[nearAddress]
+  }
+
+  // Check for chain prefix in deployed tokens
+  for (const suffix of DEPLOYER_PATTERNS) {
+    if (nearAddress.endsWith(suffix)) {
+      const accountName = nearAddress.slice(0, -suffix.length)
+
+      // Direct prefix match (e.g., "sol-ABC123")
+      for (const [prefix, chain] of Object.entries(BRIDGE_TOKEN_PREFIXES)) {
+        if (accountName.startsWith(prefix)) {
+          return chain
+        }
+      }
+
+      // Nested prefix match (e.g., "some.eth-token")
+      for (const [prefix, chain] of Object.entries(BRIDGE_TOKEN_PREFIXES)) {
+        if (accountName.includes(`.${prefix.slice(0, -1)}-`)) {
+          return chain
+        }
+      }
+    }
+  }
+
+  return null
+}

--- a/packages/core/tests/bridge-token.test.ts
+++ b/packages/core/tests/bridge-token.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+import { ChainKind } from "../src/types.js"
+import { isBridgeToken, parseOriginChain } from "../src/utils/bridge-token.js"
+
+describe("Bridge Token Utils", () => {
+  describe("isBridgeToken", () => {
+    it("should return true for native bridge tokens on mainnet", () => {
+      expect(isBridgeToken("nbtc.bridge.near")).toBe(true)
+      expect(isBridgeToken("nzec.bridge.near")).toBe(true)
+    })
+
+    it("should return true for native bridge tokens on testnet", () => {
+      expect(isBridgeToken("nbtc.n-bridge.testnet")).toBe(true)
+      expect(isBridgeToken("nzcash.n-bridge.testnet")).toBe(true)
+    })
+
+    it("should return true for deployed bridge tokens with chain prefixes", () => {
+      expect(isBridgeToken("eth-abc123.omdep.near")).toBe(true)
+      expect(isBridgeToken("sol-xyz789.omdep.near")).toBe(true)
+      expect(isBridgeToken("arb-token.omdep.near")).toBe(true)
+      expect(isBridgeToken("base-usdc.omdep.near")).toBe(true)
+      expect(isBridgeToken("bnb-token.omdep.near")).toBe(true)
+      expect(isBridgeToken("pol-matic.omdep.near")).toBe(true)
+    })
+
+    it("should return true for tokens under bridge.near suffix", () => {
+      expect(isBridgeToken("some-token.bridge.near")).toBe(true)
+    })
+
+    it("should return true for tokens under n-bridge.testnet suffix", () => {
+      expect(isBridgeToken("some-token.n-bridge.testnet")).toBe(true)
+    })
+
+    it("should return false for regular NEAR accounts", () => {
+      expect(isBridgeToken("alice.near")).toBe(false)
+      expect(isBridgeToken("random.testnet")).toBe(false)
+      expect(isBridgeToken("wrap.near")).toBe(false)
+      expect(isBridgeToken("usdt.tether-token.near")).toBe(false)
+    })
+
+    it("should return false for similar but non-bridge addresses", () => {
+      expect(isBridgeToken("notbridge.near")).toBe(false)
+      expect(isBridgeToken("my-bridge.near")).toBe(false)
+    })
+  })
+
+  describe("parseOriginChain", () => {
+    it("should return ChainKind.Btc for nbtc tokens", () => {
+      expect(parseOriginChain("nbtc.bridge.near")).toBe(ChainKind.Btc)
+      expect(parseOriginChain("nbtc.n-bridge.testnet")).toBe(ChainKind.Btc)
+    })
+
+    it("should return ChainKind.Zcash for nzec tokens", () => {
+      expect(parseOriginChain("nzec.bridge.near")).toBe(ChainKind.Zcash)
+      expect(parseOriginChain("nzcash.n-bridge.testnet")).toBe(ChainKind.Zcash)
+    })
+
+    it("should parse chain from deployed tokens with eth prefix", () => {
+      expect(parseOriginChain("eth-abc123.omdep.near")).toBe(ChainKind.Eth)
+      expect(parseOriginChain("eth-usdc.bridge.near")).toBe(ChainKind.Eth)
+    })
+
+    it("should parse chain from deployed tokens with sol prefix", () => {
+      expect(parseOriginChain("sol-xyz789.omdep.near")).toBe(ChainKind.Sol)
+    })
+
+    it("should parse chain from deployed tokens with arb prefix", () => {
+      expect(parseOriginChain("arb-token.omdep.near")).toBe(ChainKind.Arb)
+    })
+
+    it("should parse chain from deployed tokens with base prefix", () => {
+      expect(parseOriginChain("base-usdc.omdep.near")).toBe(ChainKind.Base)
+    })
+
+    it("should parse chain from deployed tokens with bnb prefix", () => {
+      expect(parseOriginChain("bnb-token.omdep.near")).toBe(ChainKind.Bnb)
+    })
+
+    it("should parse chain from deployed tokens with pol prefix", () => {
+      expect(parseOriginChain("pol-matic.omdep.near")).toBe(ChainKind.Pol)
+    })
+
+    it("should return null for non-bridge tokens", () => {
+      expect(parseOriginChain("alice.near")).toBe(null)
+      expect(parseOriginChain("wrap.near")).toBe(null)
+      expect(parseOriginChain("random.testnet")).toBe(null)
+    })
+
+    it("should return null for bridge suffix without chain prefix", () => {
+      expect(parseOriginChain("unknown-token.bridge.near")).toBe(null)
+    })
+  })
+})

--- a/packages/near/src/builder.ts
+++ b/packages/near/src/builder.ts
@@ -34,6 +34,10 @@ import {
 
 export interface NearBuilderConfig {
   network: Network
+  /**
+   * Custom NEAR RPC URL. If not provided, uses the default RPC for the network.
+   */
+  rpcUrl?: string
 }
 
 /**
@@ -226,9 +230,11 @@ function encodeArgs(args: unknown): Uint8Array {
 class NearBuilderImpl implements NearBuilder {
   private readonly bridgeContract: string
   readonly network: Network
+  private readonly rpcUrl: string | undefined
 
-  constructor(network: Network) {
+  constructor(network: Network, rpcUrl: string | undefined) {
     this.network = network
+    this.rpcUrl = rpcUrl
     const addresses = getAddresses(network)
     this.bridgeContract = addresses.near.contract
   }
@@ -762,7 +768,9 @@ class NearBuilderImpl implements NearBuilder {
   }
 
   private getNearClient(): Near {
-    return new Near({ network: this.network as "mainnet" | "testnet" })
+    return this.rpcUrl
+      ? new Near({ rpcUrl: this.rpcUrl, network: this.network as "mainnet" | "testnet" })
+      : new Near({ network: this.network as "mainnet" | "testnet" })
   }
 }
 
@@ -770,5 +778,5 @@ class NearBuilderImpl implements NearBuilder {
  * Create a NEAR transaction builder
  */
 export function createNearBuilder(config: NearBuilderConfig): NearBuilder {
-  return new NearBuilderImpl(config.network)
+  return new NearBuilderImpl(config.network, config.rpcUrl)
 }


### PR DESCRIPTION
## Summary

- Add `isBridgeToken(nearAddress)` - validates if a NEAR address is a recognized omni bridge token
- Add `parseOriginChain(nearAddress)` - parses the origin chain from a NEAR token address offline
- Fix `rpcUrls` config option being ignored in `createBridge()` and `createNearBuilder()`

## Usage

```ts
import { isBridgeToken, parseOriginChain, ChainKind } from "@omni-bridge/core"

isBridgeToken("nbtc.bridge.near") // true
isBridgeToken("sol-ABC123.omdep.near") // true  
isBridgeToken("random.near") // false

parseOriginChain("nbtc.bridge.near") // ChainKind.Btc
parseOriginChain("sol-ABC123.omdep.near") // ChainKind.Sol
parseOriginChain("random.near") // null
```

Custom RPC URL:

```ts
import { createBridge, ChainKind } from "@omni-bridge/core"

const bridge = createBridge({
  network: "mainnet",
  rpcUrls: { [ChainKind.Near]: "https://my-custom-rpc.example.com" }
})
```

Addresses feedback from https://nearone.slack.com/archives/C09UZ1T5EJG/p1769606246716169