### PR TITLE
fix(core,near): use custom rpcUrls config in createBridge and createNearBuilder

### DIFF
--- a/.changeset/fix-custom-rpc-url.md
+++ b/.changeset/fix-custom-rpc-url.md
@@ -1,0 +1,13 @@
+---
+"@omni-bridge/core": patch
+"@omni-bridge/near": patch
+---
+
+Fix custom RPC URL support in createBridge and createNearBuilder
+
+The `rpcUrls` config option in `createBridge()` was defined but never used. This fix:
+
+- Uses the custom NEAR RPC URL from `rpcUrls[ChainKind.Near]` when creating the internal Near client in `createBridge()`
+- Adds `rpcUrl` option to `NearBuilderConfig` for `createNearBuilder()`
+
+This allows users to specify custom RPC endpoints to avoid rate limiting on default public RPCs.

--- a/docs/reference/near.mdx
+++ b/docs/reference/near.mdx
@@ -86,6 +86,10 @@ function createNearBuilder(config: NearBuilderConfig): NearBuilder
     <ResponseField name="network" type="'mainnet' | 'testnet'" required>
       The network to connect to.
     </ResponseField>
+
+    <ResponseField name="rpcUrl" type="string">
+      Optional custom NEAR RPC URL. If not provided, uses the default RPC for the network.
+    </ResponseField>
   </Expandable>
 </ResponseField>
 
@@ -100,7 +104,14 @@ function createNearBuilder(config: NearBuilderConfig): NearBuilder
 ```typescript
 import { createNearBuilder } from "@omni-bridge/near"
 
+// Basic usage
 const nearBuilder = createNearBuilder({ network: "mainnet" })
+
+// With custom RPC URL (to avoid rate limiting)
+const nearBuilderWithRpc = createNearBuilder({
+  network: "mainnet",
+  rpcUrl: "https://my-custom-rpc.example.com",
+})
 ```
 
 ---

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -162,7 +162,12 @@ class BridgeImpl implements Bridge {
     this.network = config.network
     this.addresses = getAddresses(config.network)
     this.api = new BridgeAPI(config.network)
-    this.near = new Near({ network: config.network })
+
+    // Use custom NEAR RPC URL if provided, otherwise use default network config
+    const nearRpcUrl = config.rpcUrls?.[ChainKind.Near]
+    this.near = nearRpcUrl
+      ? new Near({ rpcUrl: nearRpcUrl, network: config.network })
+      : new Near({ network: config.network })
   }
 
   async validateTransfer(params: TransferParams): Promise<ValidatedTransfer> {

--- a/packages/near/src/builder.ts
+++ b/packages/near/src/builder.ts
@@ -34,6 +34,10 @@ import {
 
 export interface NearBuilderConfig {
   network: Network
+  /**
+   * Custom NEAR RPC URL. If not provided, uses the default RPC for the network.
+   */
+  rpcUrl?: string
 }
 
 /**
@@ -226,9 +230,11 @@ function encodeArgs(args: unknown): Uint8Array {
 class NearBuilderImpl implements NearBuilder {
   private readonly bridgeContract: string
   readonly network: Network
+  private readonly rpcUrl: string | undefined
 
-  constructor(network: Network) {
+  constructor(network: Network, rpcUrl: string | undefined) {
     this.network = network
+    this.rpcUrl = rpcUrl
     const addresses = getAddresses(network)
     this.bridgeContract = addresses.near.contract
   }
@@ -762,7 +768,9 @@ class NearBuilderImpl implements NearBuilder {
   }
 
   private getNearClient(): Near {
-    return new Near({ network: this.network as "mainnet" | "testnet" })
+    return this.rpcUrl
+      ? new Near({ rpcUrl: this.rpcUrl, network: this.network as "mainnet" | "testnet" })
+      : new Near({ network: this.network as "mainnet" | "testnet" })
   }
 }
 
@@ -770,5 +778,5 @@ class NearBuilderImpl implements NearBuilder {
  * Create a NEAR transaction builder
  */
 export function createNearBuilder(config: NearBuilderConfig): NearBuilder {
-  return new NearBuilderImpl(config.network)
+  return new NearBuilderImpl(config.network, config.rpcUrl)
 }


### PR DESCRIPTION
## Summary

The `rpcUrls` config option in `createBridge()` was defined but never used. This fix:

- Uses the custom NEAR RPC URL from `rpcUrls[ChainKind.Near]` when creating the internal Near client
- Adds `rpcUrl` option to `NearBuilderConfig` for `createNearBuilder()`

## Usage

```ts
import { createBridge, ChainKind } from "@omni-bridge/core"

const bridge = createBridge({
  network: "mainnet",
  rpcUrls: { [ChainKind.Near]: "https://my-custom-rpc.example.com" }
})
```

```ts
import { createNearBuilder } from "@omni-bridge/near"

const builder = createNearBuilder({
  network: "mainnet",
  rpcUrl: "https://my-custom-rpc.example.com"
})
```

Addresses feedback from https://nearone.slack.com/archives/C09UZ1T5EJG/p1769606246716169