### PR TITLE
fix(core): replace deprecated nzec.bridge.near with zec.omft.near

### DIFF
--- a/.changeset/remove-deprecated-nzec.md
+++ b/.changeset/remove-deprecated-nzec.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/core": patch
+---
+
+Replace deprecated `nzec.bridge.near` with `zec.omft.near` for mainnet Zcash token

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -80,7 +80,7 @@ const MAINNET_ADDRESSES: ChainAddresses = {
     apiUrl: "https://zcash-mainnet.gateway.tatum.io/",
     rpcUrl: "https://zcash-mainnet.gateway.tatum.io/",
     zcashConnector: "zcash-connector.bridge.near",
-    zcashToken: "nzec.bridge.near",
+    zcashToken: "zec.omft.near",
   },
 }
 

--- a/packages/near/tests/utxo.test.ts
+++ b/packages/near/tests/utxo.test.ts
@@ -224,7 +224,7 @@ describe("NearBuilder UTXO methods", () => {
     })
 
     it("uses mainnet Zcash token address", () => {
-      expect(mainnetBuilder.getUtxoTokenAddress("zcash")).toBe("nzec.bridge.near")
+      expect(mainnetBuilder.getUtxoTokenAddress("zcash")).toBe("zec.omft.near")
     })
   })
 })


### PR DESCRIPTION
Replace deprecated `nzec.bridge.near` with PoA token `zec.omft.near` for mainnet Zcash.

Addresses https://nearone.slack.com/archives/C09UZ1T5EJG/p1769748957561729