### PR TITLE
fix(core): remove deprecated nzec.bridge.near from token utilities

### DIFF
--- a/.changeset/remove-nzec-token-utils.md
+++ b/.changeset/remove-nzec-token-utils.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/core": patch
+---
+
+Remove deprecated `nzec.bridge.near` from token utilities

--- a/packages/core/src/utils/token.ts
+++ b/packages/core/src/utils/token.ts
@@ -11,7 +11,6 @@ import { ChainKind } from "../types.js"
 const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
   // Mainnet
   "nbtc.bridge.near": ChainKind.Btc,
-  "nzec.bridge.near": ChainKind.Zcash,
   "zec.omft.near": ChainKind.Zcash,
   "eth.bridge.near": ChainKind.Eth,
   "sol.omdep.near": ChainKind.Sol,

--- a/packages/core/tests/token.test.ts
+++ b/packages/core/tests/token.test.ts
@@ -6,7 +6,6 @@ describe("Token Utils", () => {
   describe("isBridgeToken", () => {
     it("should return true for known mainnet bridge tokens", () => {
       expect(isBridgeToken("nbtc.bridge.near")).toBe(true)
-      expect(isBridgeToken("nzec.bridge.near")).toBe(true)
       expect(isBridgeToken("zec.omft.near")).toBe(true)
       expect(isBridgeToken("eth.bridge.near")).toBe(true)
       expect(isBridgeToken("sol.omdep.near")).toBe(true)
@@ -48,7 +47,6 @@ describe("Token Utils", () => {
       })
 
       it("should parse mainnet Zcash token", () => {
-        expect(parseOriginChain("nzec.bridge.near")).toBe(ChainKind.Zcash)
         expect(parseOriginChain("zec.omft.near")).toBe(ChainKind.Zcash)
       })
 


### PR DESCRIPTION
Remove deprecated `nzec.bridge.near` from `isBridgeToken` and `parseOriginChain` utilities.