### PR TITLE
fix(docs): correct token decimals - bridge preserves origin decimals

### DIFF
--- a/docs/core-concepts/decimals.mdx
+++ b/docs/core-concepts/decimals.mdx
@@ -9,23 +9,33 @@ description: Why small amounts can fail and how to prevent it
 
 ## The Problem
 
-Different chains use different decimal precisions for the same token:
+Different chains use different decimal precisions for the same token. The bridge preserves origin decimals unless they exceed the destination chain's maximum:
+
+| Chain | Maximum Decimals |
+|-------|------------------|
+| NEAR | No limit (keeps origin) |
+| EVM | 18 |
+| Solana | 9 |
+
+For example, bridged tokens on NEAR keep their original decimals:
 
 | Token | Ethereum | NEAR | Solana |
 |-------|----------|------|--------|
-| USDC | 6 decimals | 24 decimals | 6 decimals |
-| WETH | 18 decimals | 24 decimals | 8 decimals |
+| USDC | 6 decimals | 6 decimals | 6 decimals |
+| WETH | 18 decimals | 18 decimals | 8 decimals (capped from 18) |
+| wNEAR | 24 decimals | 24 decimals | 9 decimals (capped from 24) |
 
 When bridging tokens, amounts must be converted between these precisions. Small amounts can round to zero during conversion — and a zero-amount transfer fails.
 
 ## Example: The Dust Problem
 
-Suppose you try to bridge 0.0000001 USDC from NEAR (24 decimals) to Ethereum (6 decimals):
+Suppose you try to bridge 0.0000001 USDC from NEAR (6 decimals) to Solana (6 decimals), but with a very small fee:
 
 ```typescript
-// On NEAR: 0.0000001 USDC = 100000000000000000 (24 decimals)
-// Converted to Ethereum: rounds down to 0 (6 decimals)
-// Result: transfer fails
+// wNEAR bridged to Ethereum: 24 decimals → 18 decimals
+// On NEAR: 0.0000001 wNEAR = 100000000000000000 (24 decimals)
+// Converted to Ethereum: rounds down to 10000000000 (18 decimals)
+// If this is smaller than fees, transfer fails
 ```
 
 This is called "dust" — amounts so small they disappear during conversion.
@@ -80,7 +90,7 @@ import { getMinimumTransferableAmount } from "@omni-bridge/core"
 import { formatUnits } from "viem"
 
 const sourceDecimals = 6   // USDC on Ethereum
-const destDecimals = 24    // USDC on NEAR
+const destDecimals = 6     // USDC on NEAR (keeps origin decimals)
 
 const minAmount = getMinimumTransferableAmount(sourceDecimals, destDecimals)
 const minDisplay = formatUnits(minAmount, sourceDecimals)
@@ -136,3 +146,20 @@ await bridge.validateTransfer({
 2. **Check minimums in your UI** — Show users the minimum before they submit
 3. **Handle `AMOUNT_TOO_SMALL` errors** — Give users a helpful message
 4. **Remember fees reduce the amount** — The net amount must survive, not just the gross
+
+## Querying Actual Token Decimals
+
+To verify the exact decimals for any registered token, query the bridge contract:
+
+```typescript
+const decimals = await bridge.getTokenDecimals(
+  "eth:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // USDC on Ethereum
+)
+
+if (decimals) {
+  console.log(`On foreign chain: ${decimals.decimals}`)      // 6 for USDC
+  console.log(`On NEAR: ${decimals.origin_decimals}`)        // 6 for USDC
+}
+```
+
+This queries the NEAR bridge contract's `get_token_decimals` method and returns the actual registered values.

--- a/docs/reference/evm.mdx
+++ b/docs/reference/evm.mdx
@@ -463,11 +463,13 @@ builder.buildDeployToken(
 #### Example
 
 ```typescript
+// Note: Pass the source token's decimals - the EVM contract
+// normalizes to max 18 decimals automatically
 const deployTx = evm.buildDeployToken(signature, {
   token: "wrap.near",
   name: "Wrapped NEAR",
   symbol: "wNEAR",
-  decimals: 24,
+  decimals: 24, // Source decimals; will be 18 on EVM
 })
 
 await walletClient.sendTransaction(deployTx)

--- a/docs/reference/solana.mdx
+++ b/docs/reference/solana.mdx
@@ -338,11 +338,13 @@ import { PublicKey, Transaction } from "@solana/web3.js"
 
 const solana = createSolanaBuilder({ network: "mainnet" })
 
+// Note: Pass the source token's decimals - the Solana program
+// normalizes to max 9 decimals automatically
 const metadata = {
   token: "near:wrap.near",
   name: "Wrapped NEAR",
   symbol: "wNEAR",
-  decimals: 24,
+  decimals: 24, // Source decimals; will be 9 on Solana
 }
 
 const signature = {


### PR DESCRIPTION
## Summary

Fixes incorrect documentation about token decimals on NEAR. The docs incorrectly stated USDC/WETH use 24 decimals on NEAR.

## Changes

- Corrected decimals table: USDC=6, WETH=18 on NEAR (not 24)
- Added chain maximum decimals info (NEAR: no limit, EVM: 18, Solana: 9)
- Added comments in deploy examples clarifying normalization behavior
- Added section on querying actual decimals via `getTokenDecimals()`

## Verification

Queried live NEAR bridge contract (`omni.bridge.near`):
- USDC: 6 decimals on both Ethereum and NEAR
- WETH: 18 decimals on both Ethereum and NEAR

Confirmed via contract code:
- EVM: `_normalizeDecimals()` caps at 18
- Solana: `MAX_ALLOWED_DECIMALS` = 9
- NEAR: No normalization, keeps origin decimals