### PR TITLE
fix(core): support HlEvm/Strk transfer API responses

### DIFF
--- a/.changeset/rare-buses-paint.md
+++ b/.changeset/rare-buses-paint.md
@@ -1,0 +1,6 @@
+---
+"@omni-bridge/core": patch
+---
+
+Add support for the new `HlEvm` and `Strk` transfer API chain enums and parse
+the new `Starknet` transaction variant in transfer responses.

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -18,6 +18,7 @@ const ChainSchema = z.enum([
   "Btc",
   "Zcash",
   "Pol",
+  "Abs",
   "HlEvm",
   "Strk",
 ])

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -8,7 +8,19 @@ import { OmniBridgeError } from "./errors.js"
 import type { Network, OmniAddress } from "./types.js"
 
 // API response schemas
-const ChainSchema = z.enum(["Eth", "Near", "Sol", "Arb", "Base", "Bnb", "Btc", "Zcash", "Pol"])
+const ChainSchema = z.enum([
+  "Eth",
+  "Near",
+  "Sol",
+  "Arb",
+  "Base",
+  "Bnb",
+  "Btc",
+  "Zcash",
+  "Pol",
+  "HlEvm",
+  "Strk",
+])
 export type Chain = z.infer<typeof ChainSchema>
 
 const TransferStatusSchema = z.enum([
@@ -76,18 +88,29 @@ const UtxoLogTransactionSchema = z.object({
   block_time: z.number().int().min(0).nullable(),
 })
 
+const StarknetTransactionSchema = z.object({
+  block_number: z.number().int().min(0),
+  block_timestamp: z.number().int().min(0),
+  transaction_hash: z.string(),
+})
+
 const TransactionSchema = z
   .object({
     NearReceipt: NearReceiptTransactionSchema.optional(),
     EVMLog: EVMLogTransactionSchema.optional(),
     Solana: SolanaTransactionSchema.optional(),
     UtxoLog: UtxoLogTransactionSchema.optional(),
+    Starknet: StarknetTransactionSchema.optional(),
   })
   .refine(
     (data) => {
-      const definedFields = [data.NearReceipt, data.EVMLog, data.Solana, data.UtxoLog].filter(
-        (field) => field !== undefined,
-      )
+      const definedFields = [
+        data.NearReceipt,
+        data.EVMLog,
+        data.Solana,
+        data.UtxoLog,
+        data.Starknet,
+      ].filter((field) => field !== undefined)
       return definedFields.length === 1
     },
     { message: "Exactly one transaction type must be present" },

--- a/packages/core/tests/api.test.ts
+++ b/packages/core/tests/api.test.ts
@@ -46,6 +46,31 @@ const normalizedTransfer = {
   ...mockTransfer,
 }
 
+const mockStarknetTransfer = {
+  id: {
+    origin_chain: "Strk",
+    kind: {
+      Nonce: 456,
+    },
+  },
+  initialized: {
+    Starknet: {
+      block_number: 100,
+      block_timestamp: 1730000000,
+      transaction_hash: "0xstarknettx",
+    },
+  },
+  signed: null,
+  fast_finalised_on_near: null,
+  finalised_on_near: null,
+  fast_finalised: null,
+  finalised: null,
+  claimed: null,
+  transfer_message: null,
+  updated_fee: [],
+  utxo_transfer: null,
+}
+
 const mockFee = {
   native_token_fee: 5000,
   gas_fee: null,
@@ -115,6 +140,11 @@ describe("BridgeAPI", () => {
       expect(status).toEqual(["Initialized"])
     })
 
+    it("should accept new chain enums", async () => {
+      const status = await api.getTransferStatus({ originChain: "HlEvm", originNonce: 123 })
+      expect(status).toEqual(["Initialized"])
+    })
+
     it("should handle 404 error", async () => {
       server.use(
         http.get(`${BASE_URL}/api/v3/transfers/transfer/status`, () => {
@@ -171,6 +201,17 @@ describe("BridgeAPI", () => {
     it("should fetch transfer by transaction hash", async () => {
       const transfers = await api.getTransfer({ transactionHash: "0x123..." })
       expect(transfers).toEqual([normalizedTransfer])
+    })
+
+    it("should parse Starknet transaction payloads", async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/v3/transfers/transfer`, () => {
+          return HttpResponse.json([mockStarknetTransfer])
+        }),
+      )
+
+      const transfers = await api.getTransfer({ originChain: "Strk", originNonce: 456 })
+      expect(transfers).toEqual([mockStarknetTransfer])
     })
   })
 


### PR DESCRIPTION
## Summary
- extend core API `Chain` parsing to accept the new `HlEvm` and `Strk` `origin_chain` values returned by bridge-indexer
- add Starknet transaction variant parsing (`Starknet`) so transfer payload validation succeeds with the updated API schema
- add API tests covering new chain enums and Starknet transfer payloads

## Validation
- `bun run test packages/core/`
- `bun run typecheck`

Related to https://github.com/Near-One/bridge-indexer-rs/pull/306