### PR TITLE
feat(near): add buildUtxoWithdrawalSign, revert Zcash token address

### DIFF
--- a/.changeset/btc-sign-and-zcash-rollback.md
+++ b/.changeset/btc-sign-and-zcash-rollback.md
@@ -1,0 +1,6 @@
+---
+"@omni-bridge/near": minor
+"@omni-bridge/core": patch
+---
+
+Add `buildUtxoWithdrawalSign()` for manually triggering MPC signing on stuck BTC/Zcash withdrawals. Revert Zcash mainnet token address to `nzec.bridge.near` since the `zec.omft.near` migration never happened.

--- a/.changeset/btc-sign-and-zcash-rollback.md
+++ b/.changeset/btc-sign-and-zcash-rollback.md
@@ -3,4 +3,4 @@
 "@omni-bridge/core": patch
 ---
 
-Add `buildUtxoWithdrawalSign()` for manually triggering MPC signing on stuck BTC/Zcash withdrawals. Revert Zcash mainnet token address to `nzec.bridge.near` since the `zec.omft.near` migration never happened.
+Add `buildUtxoWithdrawalSubmit()` and `buildUtxoWithdrawalSign()` for manually unsticking BTC/Zcash withdrawals. Revert Zcash mainnet token address to `nzec.bridge.near` since the `zec.omft.near` migration never happened.

--- a/e2e/near-to-btc.test.ts
+++ b/e2e/near-to-btc.test.ts
@@ -333,4 +333,146 @@ describe("NEAR to BTC Withdrawal E2E Test", () => {
     },
     TIMEOUTS.FULL_E2E_FLOW * 2, // 10 minutes for full flow with signing wait
   )
+
+  test(
+    "should manually sign a BTC withdrawal (unstuck flow)",
+    async () => {
+      console.log("\n🔧 Testing manual signing (unstuck) flow...")
+
+      // Step 1: Check balance
+      const balance = await nearBuilder.getUtxoTokenBalance("btc", signerId)
+      const config = await nearBuilder.getUtxoConnectorConfig("btc")
+      const minWithdraw = BigInt(config.min_withdraw_amount)
+
+      if (balance < minWithdraw) {
+        console.log(`  ⚠️ Insufficient nBTC balance (${balance} < ${minWithdraw}), skipping`)
+        return
+      }
+
+      // Step 2: Build plan and initiate withdrawal
+      const utxos: UTXO[] = await nearBuilder.getUtxoAvailableOutputs("btc")
+      if (utxos.length === 0) {
+        console.log("  ⚠️ No UTXOs available, skipping")
+        return
+      }
+
+      const plan = btcBuilder.buildWithdrawalPlan(
+        utxos,
+        minWithdraw,
+        BITCOIN_TESTNET_ADDRESS,
+        config.change_address,
+        2,
+      )
+
+      const bridgeFee = await nearBuilder.calculateUtxoWithdrawalFee("btc", minWithdraw)
+      const totalAmount = minWithdraw + plan.fee + bridgeFee
+
+      if (balance < totalAmount) {
+        console.log("  ⚠️ Insufficient balance for total amount, skipping")
+        return
+      }
+
+      console.log("  Initiating withdrawal...")
+      const withdrawTx = nearBuilder.buildUtxoWithdrawalInit({
+        chain: "btc",
+        targetAddress: BITCOIN_TESTNET_ADDRESS,
+        inputs: plan.inputs,
+        outputs: plan.outputs,
+        totalAmount,
+        signerId,
+      })
+
+      const initResult = await toNearKitTransaction(near, withdrawTx).send({ waitUntil: "FINAL" })
+      console.log(`  ✓ NEAR TX: ${initResult.transaction.hash}`)
+
+      // Step 3: Extract pending sign ID from logs
+      const pendingLog = initResult.receipts_outcome
+        .flatMap((receipt) => receipt.outcome.logs)
+        .find((log) => log.includes("generate_btc_pending_info"))
+
+      if (!pendingLog) {
+        console.log("  ⚠️ No pending info found, skipping manual sign")
+        return
+      }
+
+      const pendingParts = pendingLog.split("EVENT_JSON:")
+      if (!pendingParts[1]) {
+        console.log("  ⚠️ Could not parse pending event, skipping")
+        return
+      }
+
+      const pendingData = JSON.parse(pendingParts[1])
+      const pendingSignId = pendingData.data?.[0]?.btc_pending_id
+      const inputCount = plan.inputs.length
+
+      console.log(`  ✓ Pending Sign ID: ${pendingSignId}`)
+      console.log(`  Inputs to sign: ${inputCount}`)
+
+      // Step 4: Manually sign each input using buildUtxoWithdrawalSign
+      for (let i = 0; i < inputCount; i++) {
+        console.log(`  Signing input ${i}...`)
+        const signTx = nearBuilder.buildUtxoWithdrawalSign({
+          chain: "btc",
+          pendingSignId: pendingSignId,
+          signIndex: i,
+          signerId,
+        })
+
+        // Verify transaction structure
+        expect(signTx.receiverId).toBe(nearBuilder.getUtxoConnectorAddress("btc"))
+        expect(signTx.actions[0]?.methodName).toBe("sign_btc_transaction")
+
+        try {
+          const signResult = await toNearKitTransaction(near, signTx).send({
+            waitUntil: "FINAL",
+          })
+          console.log(`  ✓ Signed input ${i}: ${signResult.transaction.hash}`)
+
+          // Check for signed_btc_transaction event in the last input's result
+          if (i === inputCount - 1) {
+            const signedLog = signResult.receipts_outcome
+              .flatMap((receipt) => receipt.outcome.logs)
+              .find((log) => log.includes("signed_btc_transaction"))
+
+            if (signedLog) {
+              console.log("  ✓ Got signed_btc_transaction event - manual signing works!")
+
+              // Extract and broadcast
+              const signedTxHex = await getSignedTxBytes(
+                near,
+                signResult.transaction.hash,
+                signerId,
+              )
+              console.log(`  ✓ Signed tx: ${signedTxHex.length / 2} bytes`)
+
+              try {
+                const btcTxHash = await btcBuilder.broadcastTransaction(signedTxHex)
+                console.log(`  ✓ Broadcast: ${btcTxHash}`)
+              } catch (error) {
+                const msg = (error as Error).message
+                if (msg.includes("already in block chain") || msg.includes("already known")) {
+                  console.log("  ✓ Already broadcast by relayer (race condition, still valid)")
+                } else {
+                  console.log(`  ⚠️ Broadcast failed: ${msg}`)
+                }
+              }
+            } else {
+              console.log("  ℹ️ No signed_btc_transaction yet (may need more confirmations)")
+            }
+          }
+        } catch (error) {
+          const msg = (error as Error).message
+          if (msg.includes("already signed") || msg.includes("AlreadySigned")) {
+            console.log(`  ✓ Input ${i} already signed by relayer (race condition, method works)`)
+          } else {
+            console.log(`  ⚠️ Sign failed for input ${i}: ${msg}`)
+            throw error
+          }
+        }
+      }
+
+      console.log("\n🎉 Manual signing flow completed!")
+    },
+    TIMEOUTS.FULL_E2E_FLOW * 2,
+  )
 })

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -80,7 +80,7 @@ const MAINNET_ADDRESSES: ChainAddresses = {
     apiUrl: "https://zcash-mainnet.gateway.tatum.io/",
     rpcUrl: "https://zcash-mainnet.gateway.tatum.io/",
     zcashConnector: "zcash-connector.bridge.near",
-    zcashToken: "zec.omft.near",
+    zcashToken: "nzec.bridge.near",
   },
 }
 

--- a/packages/core/src/utils/token.ts
+++ b/packages/core/src/utils/token.ts
@@ -11,7 +11,7 @@ import { ChainKind } from "../types.js"
 const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
   // Mainnet
   "nbtc.bridge.near": ChainKind.Btc,
-  "zec.omft.near": ChainKind.Zcash,
+  "nzec.bridge.near": ChainKind.Zcash,
   "eth.bridge.near": ChainKind.Eth,
   "sol.omft.near": ChainKind.Sol,
   "base.omdep.near": ChainKind.Base,

--- a/packages/core/tests/token.test.ts
+++ b/packages/core/tests/token.test.ts
@@ -6,7 +6,7 @@ describe("Token Utils", () => {
   describe("isBridgeToken", () => {
     it("should return true for known mainnet bridge tokens", () => {
       expect(isBridgeToken("nbtc.bridge.near")).toBe(true)
-      expect(isBridgeToken("zec.omft.near")).toBe(true)
+      expect(isBridgeToken("nzec.bridge.near")).toBe(true)
       expect(isBridgeToken("eth.bridge.near")).toBe(true)
       expect(isBridgeToken("sol.omft.near")).toBe(true)
       expect(isBridgeToken("base.omdep.near")).toBe(true)
@@ -47,7 +47,7 @@ describe("Token Utils", () => {
       })
 
       it("should parse mainnet Zcash token", () => {
-        expect(parseOriginChain("zec.omft.near")).toBe(ChainKind.Zcash)
+        expect(parseOriginChain("nzec.bridge.near")).toBe(ChainKind.Zcash)
       })
 
       it("should parse mainnet ETH token", () => {

--- a/packages/near/src/builder.ts
+++ b/packages/near/src/builder.ts
@@ -28,6 +28,7 @@ import {
   type UtxoDepositFinalizationParams,
   type UtxoWithdrawalInitParams,
   type UtxoWithdrawalSignParams,
+  type UtxoWithdrawalSubmitParams,
   type UtxoWithdrawalVerifyParams,
   type WormholeVerifyProofArgs,
   WormholeVerifyProofArgsSchema,
@@ -159,6 +160,16 @@ export interface NearBuilder {
    * @returns Unsigned transaction for ft_transfer_call
    */
   buildUtxoWithdrawalInit(params: UtxoWithdrawalInitParams): NearUnsignedTransaction
+
+  /**
+   * Build a transaction to submit a UTXO withdrawal to the chain connector.
+   * Use this to "unstuck" a withdrawal when the relayer fails to submit it
+   * after the user called init_transfer on the omni bridge.
+   *
+   * @param params - Submit parameters including transfer ID and UTXO plan
+   * @returns Unsigned transaction for submit_transfer_to_utxo_chain_connector
+   */
+  buildUtxoWithdrawalSubmit(params: UtxoWithdrawalSubmitParams): NearUnsignedTransaction
 
   /**
    * Build a transaction to manually trigger MPC signing for a UTXO withdrawal input.
@@ -665,6 +676,46 @@ class NearBuilderImpl implements NearBuilder {
       type: "near",
       signerId: params.signerId,
       receiverId: token,
+      actions: [action],
+    }
+  }
+
+  buildUtxoWithdrawalSubmit(params: UtxoWithdrawalSubmitParams): NearUnsignedTransaction {
+    // Convert chain kind to string if needed
+    let originChain: string | number = params.transferId.origin_chain
+    if (typeof originChain === "number") {
+      originChain = ChainKind[originChain] ?? originChain
+    }
+
+    const withdrawMsg = {
+      Withdraw: {
+        target_btc_address: params.targetAddress,
+        input: params.inputs,
+        output: params.outputs,
+        ...(params.maxGasFee !== undefined && { max_gas_fee: params.maxGasFee.toString() }),
+      },
+    }
+
+    const args = {
+      transfer_id: {
+        origin_chain: originChain,
+        origin_nonce: Number(params.transferId.origin_nonce),
+      },
+      msg: JSON.stringify(withdrawMsg),
+    }
+
+    const action: NearAction = {
+      type: "FunctionCall",
+      methodName: "submit_transfer_to_utxo_chain_connector",
+      args: encodeArgs(args),
+      gas: GAS.UTXO_SUBMIT_WITHDRAWAL,
+      deposit: 0n,
+    }
+
+    return {
+      type: "near",
+      signerId: params.signerId,
+      receiverId: this.bridgeContract,
       actions: [action],
     }
   }

--- a/packages/near/src/builder.ts
+++ b/packages/near/src/builder.ts
@@ -673,7 +673,7 @@ class NearBuilderImpl implements NearBuilder {
     const connector = this.getUtxoConnectorAddress(params.chain)
 
     const args = {
-      btc_pending_sign_id: params.btcPendingSignId,
+      btc_pending_sign_id: params.pendingSignId,
       sign_index: params.signIndex,
       key_version: 0,
     }

--- a/packages/near/src/builder.ts
+++ b/packages/near/src/builder.ts
@@ -27,6 +27,7 @@ import {
   type UtxoConnectorConfig,
   type UtxoDepositFinalizationParams,
   type UtxoWithdrawalInitParams,
+  type UtxoWithdrawalSignParams,
   type UtxoWithdrawalVerifyParams,
   type WormholeVerifyProofArgs,
   WormholeVerifyProofArgsSchema,
@@ -158,6 +159,16 @@ export interface NearBuilder {
    * @returns Unsigned transaction for ft_transfer_call
    */
   buildUtxoWithdrawalInit(params: UtxoWithdrawalInitParams): NearUnsignedTransaction
+
+  /**
+   * Build a transaction to manually trigger MPC signing for a UTXO withdrawal input.
+   * Use this to "unstuck" a withdrawal when the relayer fails to sign.
+   * Must be called once per input in the pending transaction.
+   *
+   * @param params - Signing parameters including the pending sign ID and input index
+   * @returns Unsigned transaction for sign_btc_transaction
+   */
+  buildUtxoWithdrawalSign(params: UtxoWithdrawalSignParams): NearUnsignedTransaction
 
   /**
    * Build a transaction to verify a UTXO withdrawal on NEAR.
@@ -654,6 +665,31 @@ class NearBuilderImpl implements NearBuilder {
       type: "near",
       signerId: params.signerId,
       receiverId: token,
+      actions: [action],
+    }
+  }
+
+  buildUtxoWithdrawalSign(params: UtxoWithdrawalSignParams): NearUnsignedTransaction {
+    const connector = this.getUtxoConnectorAddress(params.chain)
+
+    const args = {
+      btc_pending_sign_id: params.btcPendingSignId,
+      sign_index: params.signIndex,
+      key_version: 0,
+    }
+
+    const action: NearAction = {
+      type: "FunctionCall",
+      methodName: "sign_btc_transaction",
+      args: encodeArgs(args),
+      gas: GAS.UTXO_SIGN_WITHDRAWAL,
+      deposit: DEPOSIT.MPC_SIGNING,
+    }
+
+    return {
+      type: "near",
+      signerId: params.signerId,
+      receiverId: connector,
       actions: [action],
     }
   }

--- a/packages/near/src/index.ts
+++ b/packages/near/src/index.ts
@@ -50,6 +50,7 @@ export {
   type UtxoWithdrawalInitParams,
   type UtxoWithdrawalOutput,
   type UtxoWithdrawalSignParams,
+  type UtxoWithdrawalSubmitParams,
   type UtxoWithdrawalVerifyParams,
   type WormholeVerifyProofArgs,
   WormholeVerifyProofArgsSchema,

--- a/packages/near/src/index.ts
+++ b/packages/near/src/index.ts
@@ -49,6 +49,7 @@ export {
   type UtxoPostAction,
   type UtxoWithdrawalInitParams,
   type UtxoWithdrawalOutput,
+  type UtxoWithdrawalSignParams,
   type UtxoWithdrawalVerifyParams,
   type WormholeVerifyProofArgs,
   WormholeVerifyProofArgsSchema,

--- a/packages/near/src/types.ts
+++ b/packages/near/src/types.ts
@@ -320,7 +320,7 @@ export interface UtxoWithdrawalSignParams {
   /** The UTXO chain (BTC or Zcash) */
   chain: "btc" | "zcash"
   /** Pending sign ID from the generate_btc_pending_info event */
-  btcPendingSignId: number
+  pendingSignId: number
   /** Index of the input to sign (one call per input) */
   signIndex: number
   /** Signer account ID */

--- a/packages/near/src/types.ts
+++ b/packages/near/src/types.ts
@@ -343,7 +343,7 @@ export interface UtxoWithdrawalSignParams {
   /** The UTXO chain (BTC or Zcash) */
   chain: "btc" | "zcash"
   /** Pending sign ID from the generate_btc_pending_info event */
-  pendingSignId: number
+  pendingSignId: string
   /** Index of the input to sign (one call per input) */
   signIndex: number
   /** Signer account ID */

--- a/packages/near/src/types.ts
+++ b/packages/near/src/types.ts
@@ -21,12 +21,14 @@ export const GAS = {
   // UTXO-specific gas constants
   UTXO_VERIFY_DEPOSIT: BigInt(parseGas("300 Tgas")),
   UTXO_INIT_WITHDRAWAL: BigInt(parseGas("100 Tgas")),
+  UTXO_SIGN_WITHDRAWAL: BigInt(parseGas("300 Tgas")),
   UTXO_VERIFY_WITHDRAWAL: BigInt(parseGas("5 Tgas")),
 } as const
 
 // Deposit constants
 export const DEPOSIT = {
   ONE_YOCTO: BigInt(parseAmount("1 yocto")),
+  MPC_SIGNING: BigInt(parseAmount("0.25 NEAR")),
 } as const
 
 /**
@@ -306,6 +308,21 @@ export interface UtxoWithdrawalInitParams {
   totalAmount: bigint
   /** Optional maximum gas fee in satoshis/zatoshis */
   maxGasFee?: bigint
+  /** Signer account ID */
+  signerId: string
+}
+
+/**
+ * Parameters for signing a UTXO withdrawal transaction via MPC.
+ * Call this for each input that needs signing when the relayer is stuck.
+ */
+export interface UtxoWithdrawalSignParams {
+  /** The UTXO chain (BTC or Zcash) */
+  chain: "btc" | "zcash"
+  /** Pending sign ID from the generate_btc_pending_info event */
+  btcPendingSignId: number
+  /** Index of the input to sign (one call per input) */
+  signIndex: number
   /** Signer account ID */
   signerId: string
 }

--- a/packages/near/src/types.ts
+++ b/packages/near/src/types.ts
@@ -21,6 +21,7 @@ export const GAS = {
   // UTXO-specific gas constants
   UTXO_VERIFY_DEPOSIT: BigInt(parseGas("300 Tgas")),
   UTXO_INIT_WITHDRAWAL: BigInt(parseGas("100 Tgas")),
+  UTXO_SUBMIT_WITHDRAWAL: BigInt(parseGas("300 Tgas")),
   UTXO_SIGN_WITHDRAWAL: BigInt(parseGas("300 Tgas")),
   UTXO_VERIFY_WITHDRAWAL: BigInt(parseGas("5 Tgas")),
 } as const
@@ -306,6 +307,28 @@ export interface UtxoWithdrawalInitParams {
   outputs: UtxoWithdrawalOutput[]
   /** Total amount to transfer (including fees) */
   totalAmount: bigint
+  /** Optional maximum gas fee in satoshis/zatoshis */
+  maxGasFee?: bigint
+  /** Signer account ID */
+  signerId: string
+}
+
+/**
+ * Parameters for submitting a UTXO withdrawal to the chain connector.
+ * Use this to "unstuck" a withdrawal when the relayer fails to submit it
+ * after the user initiated the transfer on the omni bridge.
+ */
+export interface UtxoWithdrawalSubmitParams {
+  /** The UTXO chain (BTC or Zcash) */
+  chain: "btc" | "zcash"
+  /** Transfer ID from the init_transfer event */
+  transferId: TransferId
+  /** Target BTC/Zcash address */
+  targetAddress: string
+  /** UTXO inputs in "txid:vout" format */
+  inputs: string[]
+  /** Transaction outputs */
+  outputs: UtxoWithdrawalOutput[]
   /** Optional maximum gas fee in satoshis/zatoshis */
   maxGasFee?: bigint
   /** Signer account ID */

--- a/packages/near/tests/utxo.test.ts
+++ b/packages/near/tests/utxo.test.ts
@@ -169,6 +169,43 @@ describe("NearBuilder UTXO methods", () => {
     })
   })
 
+  describe("buildUtxoWithdrawalSign", () => {
+    it("builds sign_btc_transaction for BTC", () => {
+      const tx = builder.buildUtxoWithdrawalSign({
+        chain: "btc",
+        btcPendingSignId: 42,
+        signIndex: 0,
+        signerId: "relayer.testnet",
+      })
+
+      expect(tx.type).toBe("near")
+      expect(tx.signerId).toBe("relayer.testnet")
+      expect(tx.receiverId).toBe("btc-connector.n-bridge.testnet")
+      expect(tx.actions).toHaveLength(1)
+      expect(tx.actions[0]?.methodName).toBe("sign_btc_transaction")
+      expect(tx.actions[0]?.gas).toBe(GAS.UTXO_SIGN_WITHDRAWAL)
+      expect(tx.actions[0]?.deposit).toBe(DEPOSIT.MPC_SIGNING)
+
+      const argsJson = new TextDecoder().decode(tx.actions[0]?.args)
+      const args = JSON.parse(argsJson)
+      expect(args.btc_pending_sign_id).toBe(42)
+      expect(args.sign_index).toBe(0)
+      expect(args.key_version).toBe(0)
+    })
+
+    it("builds sign_btc_transaction for Zcash", () => {
+      const tx = builder.buildUtxoWithdrawalSign({
+        chain: "zcash",
+        btcPendingSignId: 7,
+        signIndex: 1,
+        signerId: "relayer.testnet",
+      })
+
+      expect(tx.receiverId).toBe("zcash_connector.n-bridge.testnet")
+      expect(tx.actions[0]?.methodName).toBe("sign_btc_transaction")
+    })
+  })
+
   describe("buildUtxoWithdrawalVerify", () => {
     it("builds btc_verify_withdraw transaction for BTC", () => {
       const tx = builder.buildUtxoWithdrawalVerify({
@@ -224,7 +261,7 @@ describe("NearBuilder UTXO methods", () => {
     })
 
     it("uses mainnet Zcash token address", () => {
-      expect(mainnetBuilder.getUtxoTokenAddress("zcash")).toBe("zec.omft.near")
+      expect(mainnetBuilder.getUtxoTokenAddress("zcash")).toBe("nzec.bridge.near")
     })
   })
 })

--- a/packages/near/tests/utxo.test.ts
+++ b/packages/near/tests/utxo.test.ts
@@ -173,7 +173,7 @@ describe("NearBuilder UTXO methods", () => {
     it("builds sign_btc_transaction for BTC", () => {
       const tx = builder.buildUtxoWithdrawalSign({
         chain: "btc",
-        btcPendingSignId: 42,
+        pendingSignId: 42,
         signIndex: 0,
         signerId: "relayer.testnet",
       })
@@ -196,7 +196,7 @@ describe("NearBuilder UTXO methods", () => {
     it("builds sign_btc_transaction for Zcash", () => {
       const tx = builder.buildUtxoWithdrawalSign({
         chain: "zcash",
-        btcPendingSignId: 7,
+        pendingSignId: 7,
         signIndex: 1,
         signerId: "relayer.testnet",
       })

--- a/packages/near/tests/utxo.test.ts
+++ b/packages/near/tests/utxo.test.ts
@@ -233,7 +233,7 @@ describe("NearBuilder UTXO methods", () => {
     it("builds sign_btc_transaction for BTC", () => {
       const tx = builder.buildUtxoWithdrawalSign({
         chain: "btc",
-        pendingSignId: 42,
+        pendingSignId: "abc123def456",
         signIndex: 0,
         signerId: "relayer.testnet",
       })
@@ -248,7 +248,7 @@ describe("NearBuilder UTXO methods", () => {
 
       const argsJson = new TextDecoder().decode(tx.actions[0]?.args)
       const args = JSON.parse(argsJson)
-      expect(args.btc_pending_sign_id).toBe(42)
+      expect(args.btc_pending_sign_id).toBe("abc123def456")
       expect(args.sign_index).toBe(0)
       expect(args.key_version).toBe(0)
     })
@@ -256,7 +256,7 @@ describe("NearBuilder UTXO methods", () => {
     it("builds sign_btc_transaction for Zcash", () => {
       const tx = builder.buildUtxoWithdrawalSign({
         chain: "zcash",
-        pendingSignId: 7,
+        pendingSignId: "789def",
         signIndex: 1,
         signerId: "relayer.testnet",
       })

--- a/packages/near/tests/utxo.test.ts
+++ b/packages/near/tests/utxo.test.ts
@@ -1,3 +1,4 @@
+import { ChainKind } from "@omni-bridge/core"
 import { describe, expect, it } from "vitest"
 import { createNearBuilder } from "../src/builder.js"
 import { GAS, DEPOSIT } from "../src/types.js"
@@ -166,6 +167,65 @@ describe("NearBuilder UTXO methods", () => {
       const args = JSON.parse(argsJson)
       const msg = JSON.parse(args.msg)
       expect(msg.Withdraw.max_gas_fee).toBe("5000")
+    })
+  })
+
+  describe("buildUtxoWithdrawalSubmit", () => {
+    it("builds submit_transfer_to_utxo_chain_connector transaction", () => {
+      const tx = builder.buildUtxoWithdrawalSubmit({
+        chain: "btc",
+        transferId: {
+          origin_chain: ChainKind.Near,
+          origin_nonce: 123n,
+        },
+        targetAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        inputs: ["txid1:0", "txid2:1"],
+        outputs: [
+          { value: 50000, script_pubkey: "0014751e76e8199196d454941c45d1b3a323f1433bd6" },
+          { value: 10000, script_pubkey: "0014abcdef1234567890" },
+        ],
+        signerId: "relayer.testnet",
+      })
+
+      expect(tx.type).toBe("near")
+      expect(tx.signerId).toBe("relayer.testnet")
+      expect(tx.receiverId).toBe("omni.n-bridge.testnet")
+      expect(tx.actions).toHaveLength(1)
+      expect(tx.actions[0]?.methodName).toBe("submit_transfer_to_utxo_chain_connector")
+      expect(tx.actions[0]?.gas).toBe(GAS.UTXO_SUBMIT_WITHDRAWAL)
+      expect(tx.actions[0]?.deposit).toBe(0n)
+
+      const argsJson = new TextDecoder().decode(tx.actions[0]?.args)
+      const args = JSON.parse(argsJson)
+      expect(args.transfer_id.origin_chain).toBe("Near")
+      expect(args.transfer_id.origin_nonce).toBe(123)
+
+      const msg = JSON.parse(args.msg)
+      expect(msg.Withdraw.target_btc_address).toBe(
+        "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+      )
+      expect(msg.Withdraw.input).toEqual(["txid1:0", "txid2:1"])
+      expect(msg.Withdraw.output).toHaveLength(2)
+    })
+
+    it("includes max_gas_fee when provided", () => {
+      const tx = builder.buildUtxoWithdrawalSubmit({
+        chain: "btc",
+        transferId: {
+          origin_chain: ChainKind.Near,
+          origin_nonce: 456n,
+        },
+        targetAddress: "tb1qtest",
+        inputs: ["txid:0"],
+        outputs: [{ value: 10000, script_pubkey: "script" }],
+        maxGasFee: 3000n,
+        signerId: "relayer.testnet",
+      })
+
+      const argsJson = new TextDecoder().decode(tx.actions[0]?.args)
+      const args = JSON.parse(argsJson)
+      const msg = JSON.parse(args.msg)
+      expect(msg.Withdraw.max_gas_fee).toBe("3000")
     })
   })
 


### PR DESCRIPTION
## Summary
- Add `buildUtxoWithdrawalSign()` to NEAR builder for manually triggering MPC signing on stuck BTC/Zcash withdrawals (calls `sign_btc_transaction` on the UTXO connector contract)
- Revert Zcash mainnet token from `zec.omft.near` back to `nzec.bridge.near` — the OMFT migration never happened on-chain
- Re-add `nzec.bridge.near` to known bridge tokens in token utilities

## Test plan
- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] `bun run test` — all 231 tests pass (6 pre-existing e2e failures from `bun:test` import)
- [x] New unit tests for `buildUtxoWithdrawalSign` (BTC + Zcash) in `packages/near/tests/utxo.test.ts`
- [x] Updated token test expectations for `nzec.bridge.near`