### PR TITLE
Revert "chore: update sol.omdep.near to sol.omft.near for Solana migration (#452)"

### DIFF
--- a/.changeset/revert-sol-omft.md
+++ b/.changeset/revert-sol-omft.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/core": patch
+---
+
+chore: revert sol.omft.near back to sol.omdep.near (Solana not yet migrated)

--- a/packages/core/src/utils/token.ts
+++ b/packages/core/src/utils/token.ts
@@ -13,7 +13,7 @@ const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
   "nbtc.bridge.near": ChainKind.Btc,
   "nzec.bridge.near": ChainKind.Zcash,
   "eth.bridge.near": ChainKind.Eth,
-  "sol.omft.near": ChainKind.Sol,
+  "sol.omdep.near": ChainKind.Sol,
   "base.omdep.near": ChainKind.Base,
   "arb.omdep.near": ChainKind.Arb,
   "bnb.omdep.near": ChainKind.Bnb,

--- a/packages/core/tests/token.test.ts
+++ b/packages/core/tests/token.test.ts
@@ -8,7 +8,7 @@ describe("Token Utils", () => {
       expect(isBridgeToken("nbtc.bridge.near")).toBe(true)
       expect(isBridgeToken("nzec.bridge.near")).toBe(true)
       expect(isBridgeToken("eth.bridge.near")).toBe(true)
-      expect(isBridgeToken("sol.omft.near")).toBe(true)
+      expect(isBridgeToken("sol.omdep.near")).toBe(true)
       expect(isBridgeToken("base.omdep.near")).toBe(true)
       expect(isBridgeToken("arb.omdep.near")).toBe(true)
       expect(isBridgeToken("bnb.omdep.near")).toBe(true)
@@ -59,7 +59,7 @@ describe("Token Utils", () => {
       })
 
       it("should parse mainnet SOL token", () => {
-        expect(parseOriginChain("sol.omft.near")).toBe(ChainKind.Sol)
+        expect(parseOriginChain("sol.omdep.near")).toBe(ChainKind.Sol)
       })
 
       it("should parse mainnet Base token", () => {


### PR DESCRIPTION
This reverts commit c8f749594ffcaae7e272e0fa6aeb2c65d1fb086a.
