### PR TITLE
Add Zcash destination memo validation

### DIFF
--- a/.changeset/zcash-memo-validation.md
+++ b/.changeset/zcash-memo-validation.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/core": patch
+---
+
+Add destination memo typing and validation for Zcash memo handoff.

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -18,6 +18,8 @@ import {
 import { getAddress, getChain, isEvmChain } from "./utils/address.js"
 import { normalizeAmount, validateTransferAmount } from "./utils/decimals.js"
 
+const MAX_ZCASH_MEMO_BYTES = 512
+
 export interface BridgeConfig {
   network: Network
   rpcUrls?: Partial<Record<ChainKind, string>>
@@ -238,6 +240,28 @@ class BridgeImpl implements Bridge {
         throw new ValidationError("Invalid EVM recipient address", "INVALID_ADDRESS", {
           address: params.recipient,
         })
+      }
+    }
+
+    if (params.destinationMemo !== undefined) {
+      if (destChain !== ChainKind.Zcash) {
+        throw new ValidationError(
+          "Destination memo is only supported for Zcash transfers",
+          "INVALID_MEMO",
+          { destChain: ChainKind[destChain], supportedChain: ChainKind[ChainKind.Zcash] },
+        )
+      }
+
+      const byteLength = new TextEncoder().encode(params.destinationMemo).length
+      if (byteLength > MAX_ZCASH_MEMO_BYTES) {
+        throw new ValidationError(
+          `Destination memo exceeds ${MAX_ZCASH_MEMO_BYTES} bytes`,
+          "INVALID_MEMO",
+          {
+            byteLength,
+            maxByteLength: MAX_ZCASH_MEMO_BYTES,
+          },
+        )
       }
     }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -17,6 +17,7 @@ export type ValidationErrorCode =
   | "INVALID_AMOUNT"
   | "INVALID_ADDRESS"
   | "INVALID_CHAIN"
+  | "INVALID_MEMO"
   | "TOKEN_NOT_REGISTERED"
   | "DECIMAL_OVERFLOW"
   | "AMOUNT_TOO_SMALL"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,6 +83,11 @@ export interface TransferParams {
   sender: OmniAddress
   recipient: OmniAddress
   message?: string
+  /**
+   * Optional memo to attach on the destination chain. Currently supported for
+   * Zcash shielded recipients, where memos are limited to 512 bytes.
+   */
+  destinationMemo?: string
 }
 
 // Validated transfer (output from validation)

--- a/packages/core/tests/bridge.test.ts
+++ b/packages/core/tests/bridge.test.ts
@@ -80,6 +80,7 @@ describe("Bridge.validateTransfer", () => {
         if (address === "near:wrap.testnet") {
           if (chain === "Eth") return "eth:0x1234567890123456789012345678901234567890"
           if (chain === "Sol") return "sol:So11111111111111111111111111111111111111112"
+          if (chain === "Zcash") return "zcash:u1testrecipient"
         }
         return null
       }
@@ -193,6 +194,78 @@ describe("Bridge.validateTransfer", () => {
       }
 
       await expect(bridge.validateTransfer(params)).rejects.toThrow("Native fee cannot be negative")
+    })
+  })
+
+  describe("destinationMemo validation", () => {
+    const baseParams: TransferParams = {
+      token: "near:wrap.testnet" as OmniAddress,
+      amount: 1000000000000000000n,
+      fee: 0n,
+      nativeFee: 0n,
+      sender: "near:alice.testnet" as OmniAddress,
+      recipient: "zcash:u1testrecipient" as OmniAddress,
+    }
+
+    it("accepts a memo at the 512-byte Zcash limit", async () => {
+      const params: TransferParams = {
+        ...baseParams,
+        destinationMemo: "x".repeat(512),
+      }
+
+      const result = await bridge.validateTransfer(params)
+      expect(result.destChain).toBe(ChainKind.Zcash)
+      expect(result.params.destinationMemo).toBe(params.destinationMemo)
+    })
+
+    it("throws for a memo exceeding 512 bytes", async () => {
+      const params: TransferParams = {
+        ...baseParams,
+        destinationMemo: "x".repeat(513),
+      }
+
+      await expect(bridge.validateTransfer(params)).rejects.toThrow(ValidationError)
+      await expect(bridge.validateTransfer(params)).rejects.toMatchObject({
+        code: "INVALID_MEMO",
+        details: { byteLength: 513, maxByteLength: 512 },
+      })
+      await expect(bridge.validateTransfer(params)).rejects.toThrow(
+        "Destination memo exceeds 512 bytes",
+      )
+    })
+
+    it("counts bytes (not characters) for multi-byte UTF-8", async () => {
+      // Each "\u00e9" is 2 UTF-8 bytes, so 257 of them = 514 bytes.
+      const params: TransferParams = {
+        ...baseParams,
+        destinationMemo: "\u00e9".repeat(257),
+      }
+
+      await expect(bridge.validateTransfer(params)).rejects.toMatchObject({
+        code: "INVALID_MEMO",
+        details: { byteLength: 514, maxByteLength: 512 },
+      })
+    })
+
+    it("accepts an undefined memo", async () => {
+      // Sanity check: omitting destinationMemo doesn't trip the memo validator.
+      await expect(bridge.validateTransfer(baseParams)).resolves.toBeDefined()
+    })
+
+    it("rejects a destination memo on non-Zcash destinations", async () => {
+      const params: TransferParams = {
+        ...baseParams,
+        recipient: "near:bob.testnet" as OmniAddress,
+        destinationMemo: "memo for a non-Zcash transfer",
+      }
+
+      await expect(bridge.validateTransfer(params)).rejects.toMatchObject({
+        code: "INVALID_MEMO",
+        details: { destChain: "Near", supportedChain: "Zcash" },
+      })
+      await expect(bridge.validateTransfer(params)).rejects.toThrow(
+        "Destination memo is only supported for Zcash transfers",
+      )
     })
   })
 


### PR DESCRIPTION
## Package: Zcash memo support

This is the JS SDK half of a coordinated two-repo package for Zcash memo support.

Companion PR: https://github.com/Near-One/bridge-sdk-rs/pull/276

## Summary

Adds a typed `destinationMemo` field to the core transfer params and validates the Zcash memo size limit at the SDK boundary before downstream services forward the memo into the Rust bridge SDK / CLI path.

This keeps frontend / API callers able to pass the memo field uniformly while the Rust companion PR is responsible for embedding it in the destination Orchard output.

## Details

- Adds `destinationMemo?: string` to `TransferParams`.
- Adds `INVALID_MEMO` as a validation error code.
- Validates the UTF-8 byte length with `TextEncoder`, not JavaScript character count.
- Enforces the 512-byte Zcash memo limit with details containing both `byteLength` and `maxByteLength`.
- Adds focused validation tests for:
  - exactly 512 bytes accepted
  - 513 bytes rejected
  - multi-byte UTF-8 counted as bytes
  - undefined memo accepted
- Adds a patch changeset for `@omni-bridge/core`.

## Relationship to Rust PR

The Rust PR adds the actual memo-aware Zcash SDK / CLI paths and embeds the memo in Orchard shielded outputs. This JS PR provides the consumer-facing type and validation layer expected by callers before handing the memo off to that backend path.

Together, the two PRs make Zcash memo support available end-to-end while keeping existing BTC and shared BTC/Zcash paths unchanged.

## Validation

- `bun` pre-commit hook passed:
  - `biome check` on changed files
  - `tsc --build`
- `node_modules\.bin\biome.exe check packages/core/src/bridge.ts packages/core/src/types.ts packages/core/src/errors.ts packages/core/tests/bridge.test.ts .changeset/zcash-memo-validation.md`
- `node_modules\.bin\tsc.exe --build`
- `node_modules\.bin\vitest.exe run packages --pool=threads`

All package tests passed locally: 18 test files, 271 tests.
