### PR TITLE
fix(near): include Starknet, Abstract and HyperEVM in storage borsh schema

### DIFF
--- a/.changeset/fix-storage-starknet.md
+++ b/.changeset/fix-storage-starknet.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/near": patch
+---
+
+fix `calculateStorageAccountId` borsh schema to include the `HyperEvm`, `Strk`, and `Abs` `OmniAddress` variants. Without these, Starknet (and Abstract / HyperEVM) transfers fail to compute the correct NEAR storage account ID.

--- a/packages/near/src/storage.ts
+++ b/packages/near/src/storage.ts
@@ -6,6 +6,8 @@ import { sha256 } from "@noble/hashes/sha2.js"
 import { base58, hex } from "@scure/base"
 import { b } from "@zorsh/zorsh"
 
+// Variant order must match `omni_types::OmniAddress` in the Rust omni-bridge
+// repo — borsh enum discriminants are positional.
 const OmniAddressSchema = b.enum({
   Eth: b.array(b.u8(), 20),
   Near: b.string(),
@@ -16,6 +18,9 @@ const OmniAddressSchema = b.enum({
   Btc: b.string(),
   Zcash: b.string(),
   Pol: b.array(b.u8(), 20),
+  HyperEvm: b.array(b.u8(), 20),
+  Strk: b.array(b.u8(), 32),
+  Abs: b.array(b.u8(), 20),
 })
 
 /**
@@ -102,10 +107,16 @@ function parseOmniAddress(token: string) {
       return { Bnb: decodeHex(address) }
     case "pol":
       return { Pol: decodeHex(address) }
+    case "hlevm":
+      return { HyperEvm: decodeHex(address) }
     case "btc":
       return { Btc: address }
     case "zcash":
       return { Zcash: address }
+    case "strk":
+      return { Strk: decodeHex(address) }
+    case "abs":
+      return { Abs: decodeHex(address) }
     default:
       throw new Error(`Unknown chain: ${chain}`)
   }

--- a/packages/near/src/storage.ts
+++ b/packages/near/src/storage.ts
@@ -7,7 +7,8 @@ import { base58, hex } from "@scure/base"
 import { b } from "@zorsh/zorsh"
 
 // Variant order must match `omni_types::OmniAddress` in the Rust omni-bridge
-// repo — borsh enum discriminants are positional.
+// repo — borsh enum discriminants are positional. `HyperEvm` corresponds to
+// the JSON/API chain name `HlEvm` and the address prefix `hlevm:`.
 const OmniAddressSchema = b.enum({
   Eth: b.array(b.u8(), 20),
   Near: b.string(),
@@ -91,6 +92,16 @@ function parseOmniAddress(token: string) {
   }
   const decodeHex = (addr: string) => Array.from(hex.decode(addr.slice(2)))
   const decodeBase58 = (addr: string) => Array.from(base58.decode(addr))
+  // Starknet addresses are felts and often arrive with leading zero bytes
+  // stripped (e.g. `strk:0x1234`). The borsh schema needs exactly 32 bytes,
+  // so left-pad to 64 hex chars before decoding.
+  const decodeStrk = (addr: string) => {
+    const stripped = addr.startsWith("0x") || addr.startsWith("0X") ? addr.slice(2) : addr
+    if (stripped.length > 64) {
+      throw new Error(`Starknet address exceeds 32 bytes: ${addr}`)
+    }
+    return Array.from(hex.decode(stripped.padStart(64, "0")))
+  }
 
   switch (chain) {
     case "eth":
@@ -114,7 +125,7 @@ function parseOmniAddress(token: string) {
     case "zcash":
       return { Zcash: address }
     case "strk":
-      return { Strk: decodeHex(address) }
+      return { Strk: decodeStrk(address) }
     case "abs":
       return { Abs: decodeHex(address) }
     default:

--- a/packages/near/tests/storage.test.ts
+++ b/packages/near/tests/storage.test.ts
@@ -92,6 +92,23 @@ describe("calculateStorageAccountId", () => {
         sender: "near:sender.near" as const,
         msg: "",
       },
+      {
+        token: "near:strk.omdep.near",
+        amount: 1000000n,
+        recipient:
+          "strk:0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7" as const,
+        fee: { fee: 0n, native_fee: 0n },
+        sender: "near:intents.near" as const,
+        msg: "",
+      },
+      {
+        token: "near:abs.omdep.near",
+        amount: 1000000n,
+        recipient: "abs:0x742d35Cc6734C0532925a3b8D84f8FBf4D7bE86f" as const,
+        fee: { fee: 0n, native_fee: 0n },
+        sender: "near:intents.near" as const,
+        msg: "",
+      },
     ]
 
     const accountIds = messages.map(calculateStorageAccountId)

--- a/packages/near/tests/storage.test.ts
+++ b/packages/near/tests/storage.test.ts
@@ -109,6 +109,16 @@ describe("calculateStorageAccountId", () => {
         sender: "near:intents.near" as const,
         msg: "",
       },
+      {
+        // Starknet felts often arrive with leading zero bytes stripped — must
+        // be left-padded to 32 bytes for borsh serialization to succeed.
+        token: "near:strk.omdep.near",
+        amount: 1000000n,
+        recipient: "strk:0x1234" as const,
+        fee: { fee: 0n, native_fee: 0n },
+        sender: "near:intents.near" as const,
+        msg: "",
+      },
     ]
 
     const accountIds = messages.map(calculateStorageAccountId)


### PR DESCRIPTION
## Summary

`calculateStorageAccountId` in `packages/near/src/storage.ts` was missing the `HyperEvm`, `Strk` and `Abs` variants of `OmniAddress`. Borsh enum discriminants are positional, so any transfer touching Starknet (or Abstract / HyperEVM) hits the `Unknown chain` branch in `parseOmniAddress` and Starknet withdrawals never compute the correct NEAR storage account.

## Changes

- `OmniAddressSchema` appends `HyperEvm` (20-byte EVM addr), `Strk` (32-byte H256) and `Abs` (20-byte EVM addr) after `Pol`, matching `omni_types::OmniAddress` variant order in the omni-bridge contracts repo (`HyperEvm`=9, `Strk`=10, `Abs`=11).
- `parseOmniAddress` switch gets `hlevm`, `strk`, `abs` cases. `strk` decodes the H256 hex like the EVM variants do.
- Test in `storage.test.ts` exercises a `strk:` recipient and an `abs:` recipient so the schema can't silently regress again.

Existing test vectors (Eth/Near/Sol/Zcash) are untouched — discriminants 0-8 are unchanged.