### PR TITLE
fix(core): align `ChainKind` order with Rust `omni_types::ChainKind`

### DIFF
--- a/.changeset/fix-chainkind-discriminants.md
+++ b/.changeset/fix-chainkind-discriminants.md
@@ -1,0 +1,7 @@
+---
+"@omni-bridge/core": minor
+---
+
+align `ChainKind` declaration order with the Rust `omni_types::ChainKind` enum. Adds `HyperEvm = 9` and moves `Abs` to `11`. The previous order caused `b.nativeEnum(ChainKind)` (used in `FinTransferArgs`, `DeployTokenArgs`, and `BindTokenArgs`) to write the wrong borsh discriminant for Abstract — `fin_transfer`/`deploy_token`/`bind_token` payloads were decoded by the contract as `HyperEvm` instead. `Strk` (=10) was already correct and is unchanged.
+
+Numeric values of `ChainKind` members are part of the public surface, so this is a minor bump.

--- a/docs/reference/core.mdx
+++ b/docs/reference/core.mdx
@@ -947,8 +947,9 @@ enum ChainKind {
   Btc = 6,
   Zcash = 7,
   Pol = 8,
-  Abs = 9,
+  HyperEvm = 9,
   Strk = 10,
+  Abs = 11,
 }
 ```
 
@@ -979,7 +980,7 @@ type Network = "mainnet" | "testnet"
 API chain name strings.
 
 ```typescript
-type Chain = "Eth" | "Near" | "Sol" | "Arb" | "Base" | "Bnb" | "Btc" | "Zcash" | "Pol"
+type Chain = "Eth" | "Near" | "Sol" | "Arb" | "Base" | "Bnb" | "Btc" | "Zcash" | "Pol" | "Abs" | "HlEvm" | "Strk"
 ```
 
 ---

--- a/docs/reference/core.mdx
+++ b/docs/reference/core.mdx
@@ -919,6 +919,7 @@ type OmniAddress =
   | `btc:${string}`
   | `zcash:${string}`
   | `pol:${string}`
+  | `hlevm:${string}`
   | `abs:${string}`
   | `strk:${string}`
 ```
@@ -958,7 +959,7 @@ enum ChainKind {
 Chain prefix strings used in OmniAddress format.
 
 ```typescript
-type ChainPrefix = "eth" | "near" | "sol" | "arb" | "base" | "bnb" | "btc" | "zcash" | "pol" | "abs" | "strk"
+type ChainPrefix = "eth" | "near" | "sol" | "arb" | "base" | "bnb" | "btc" | "zcash" | "pol" | "hlevm" | "abs" | "strk"
 ```
 
 ---

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -114,6 +114,7 @@ function chainKindToApiChain(chain: ChainKind): Chain {
     [ChainKind.Btc]: "Btc",
     [ChainKind.Zcash]: "Zcash",
     [ChainKind.Pol]: "Pol",
+    [ChainKind.HyperEvm]: "HlEvm",
     [ChainKind.Abs]: "Abs",
     [ChainKind.Strk]: "Strk",
   }
@@ -135,6 +136,8 @@ function getContractAddress(addresses: ChainAddresses, chain: ChainKind): string
       return addresses.bnb.bridge
     case ChainKind.Pol:
       return addresses.pol.bridge
+    case ChainKind.HyperEvm:
+      throw new Error("HyperEVM bridge is not yet configured in the SDK")
     case ChainKind.Abs:
       return addresses.abs.bridge
     case ChainKind.Strk:

--- a/packages/core/src/bridge.ts
+++ b/packages/core/src/bridge.ts
@@ -137,7 +137,11 @@ function getContractAddress(addresses: ChainAddresses, chain: ChainKind): string
     case ChainKind.Pol:
       return addresses.pol.bridge
     case ChainKind.HyperEvm:
-      throw new Error("HyperEVM bridge is not yet configured in the SDK")
+      throw new ValidationError(
+        "HyperEVM bridge is not yet configured in the SDK",
+        "UNSUPPORTED_CHAIN",
+        { chain: ChainKind[chain] },
+      )
     case ChainKind.Abs:
       return addresses.abs.bridge
     case ChainKind.Strk:
@@ -194,6 +198,18 @@ class BridgeImpl implements Bridge {
       throw new ValidationError("Native fee cannot be negative", "INVALID_AMOUNT", {
         nativeFee: params.nativeFee.toString(),
       })
+    }
+
+    // HyperEVM is present in the ChainKind enum so borsh discriminants align
+    // with the on-chain contract, but transfers involving it are not yet
+    // supported by the SDK until RPC URLs and chain configs are added.
+    if (sourceChain === ChainKind.HyperEvm || destChain === ChainKind.HyperEvm) {
+      const offending = sourceChain === ChainKind.HyperEvm ? sourceChain : destChain
+      throw new ValidationError(
+        "HyperEVM transfers are not yet supported by the SDK",
+        "UNSUPPORTED_CHAIN",
+        { chain: ChainKind[offending] },
+      )
     }
 
     // Validate EVM addresses have proper checksum

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -21,6 +21,7 @@ export type ValidationErrorCode =
   | "DECIMAL_OVERFLOW"
   | "AMOUNT_TOO_SMALL"
   | "INVALID_CHECKSUM"
+  | "UNSUPPORTED_CHAIN"
 
 export class ValidationError extends OmniBridgeError {
   constructor(message: string, code: ValidationErrorCode, details?: Record<string, unknown>) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,7 +2,13 @@
  * Core types for Omni Bridge SDK
  */
 
-// Chain enumeration matching on-chain values
+// Chain enumeration matching on-chain values.
+//
+// Declaration order MUST match `omni_types::ChainKind` in the Rust omni-bridge
+// repo. `b.nativeEnum(ChainKind)` borsh-serializes the *position* of each
+// member in declaration order, not its numeric value, so a misaligned order
+// here would silently send the wrong discriminant byte for `fin_transfer`,
+// `deploy_token`, and `bind_token` payloads.
 export enum ChainKind {
   Eth = 0,
   Near = 1,
@@ -13,8 +19,9 @@ export enum ChainKind {
   Btc = 6,
   Zcash = 7,
   Pol = 8,
-  Abs = 9,
+  HyperEvm = 9,
   Strk = 10,
+  Abs = 11,
 }
 
 // Network configuration
@@ -31,6 +38,7 @@ export type OmniAddress =
   | `btc:${string}`
   | `zcash:${string}`
   | `pol:${string}`
+  | `hlevm:${string}`
   | `abs:${string}`
   | `strk:${string}`
 
@@ -149,5 +157,6 @@ export type ChainPrefix =
   | "btc"
   | "zcash"
   | "pol"
+  | "hlevm"
   | "abs"
   | "strk"

--- a/packages/core/src/utils/address.ts
+++ b/packages/core/src/utils/address.ts
@@ -16,6 +16,7 @@ const CHAIN_PREFIX_MAP: Record<ChainPrefix, ChainKind> = {
   btc: ChainKind.Btc,
   zcash: ChainKind.Zcash,
   pol: ChainKind.Pol,
+  hlevm: ChainKind.HyperEvm,
   abs: ChainKind.Abs,
   strk: ChainKind.Strk,
 }
@@ -31,6 +32,7 @@ const CHAIN_KIND_PREFIX_MAP: Record<ChainKind, ChainPrefix> = {
   [ChainKind.Btc]: "btc",
   [ChainKind.Zcash]: "zcash",
   [ChainKind.Pol]: "pol",
+  [ChainKind.HyperEvm]: "hlevm",
   [ChainKind.Abs]: "abs",
   [ChainKind.Strk]: "strk",
 }

--- a/packages/core/tests/bridge.test.ts
+++ b/packages/core/tests/bridge.test.ts
@@ -348,6 +348,48 @@ describe("Bridge.validateTransfer", () => {
     })
   })
 
+  describe("HyperEVM rejection", () => {
+    it("throws when source chain is HyperEVM (hlevm -> NEAR)", async () => {
+      const params: TransferParams = {
+        token: "hlevm:0x1234567890123456789012345678901234567890" as OmniAddress,
+        amount: 1000000000000000000n,
+        fee: 0n,
+        nativeFee: 0n,
+        sender: "hlevm:0xABCDEF0123456789ABCDEF0123456789ABCDEF01" as OmniAddress,
+        recipient: "near:alice.testnet" as OmniAddress,
+      }
+
+      await expect(bridge.validateTransfer(params)).rejects.toThrow(ValidationError)
+      await expect(bridge.validateTransfer(params)).rejects.toThrow(
+        "HyperEVM transfers are not yet supported by the SDK",
+      )
+      await expect(bridge.validateTransfer(params)).rejects.toMatchObject({
+        code: "UNSUPPORTED_CHAIN",
+        details: { chain: "HyperEvm" },
+      })
+    })
+
+    it("throws when destination chain is HyperEVM (NEAR -> hlevm)", async () => {
+      const params: TransferParams = {
+        token: "near:wrap.testnet" as OmniAddress,
+        amount: 1000000000000000000n,
+        fee: 0n,
+        nativeFee: 0n,
+        sender: "near:alice.testnet" as OmniAddress,
+        recipient: "hlevm:0xABCDEF0123456789ABCDEF0123456789ABCDEF01" as OmniAddress,
+      }
+
+      await expect(bridge.validateTransfer(params)).rejects.toThrow(ValidationError)
+      await expect(bridge.validateTransfer(params)).rejects.toThrow(
+        "HyperEVM transfers are not yet supported by the SDK",
+      )
+      await expect(bridge.validateTransfer(params)).rejects.toMatchObject({
+        code: "UNSUPPORTED_CHAIN",
+        details: { chain: "HyperEvm" },
+      })
+    })
+  })
+
   describe("contract address resolution", () => {
     it("returns correct contract for ETH source", async () => {
       const params: TransferParams = {

--- a/packages/near/tests/chain-kind-schema.test.ts
+++ b/packages/near/tests/chain-kind-schema.test.ts
@@ -1,0 +1,31 @@
+import { ChainKind } from "@omni-bridge/core"
+import { describe, expect, it } from "vitest"
+import { ChainKindSchema } from "../src/types.js"
+
+// `b.nativeEnum` serializes the position of each variant in declaration order
+// — not its numeric value. These assertions lock the wire format to match
+// `omni_types::ChainKind` in the Rust omni-bridge repo so `fin_transfer`,
+// `deploy_token`, and `bind_token` payloads can't silently drift again.
+describe("ChainKindSchema borsh discriminants", () => {
+  const cases: Array<[keyof typeof ChainKind, number]> = [
+    ["Eth", 0],
+    ["Near", 1],
+    ["Sol", 2],
+    ["Arb", 3],
+    ["Base", 4],
+    ["Bnb", 5],
+    ["Btc", 6],
+    ["Zcash", 7],
+    ["Pol", 8],
+    ["HyperEvm", 9],
+    ["Strk", 10],
+    ["Abs", 11],
+  ]
+
+  for (const [name, expectedByte] of cases) {
+    it(`serializes ${name} as ${expectedByte}`, () => {
+      const bytes = ChainKindSchema.serialize(ChainKind[name])
+      expect(bytes).toEqual(new Uint8Array([expectedByte]))
+    })
+  }
+})


### PR DESCRIPTION
## Summary

`ChainKindSchema = b.nativeEnum(ChainKind)` is used over the wire in `FinTransferArgs`, `DeployTokenArgs`, and `BindTokenArgs` (every `fin_transfer`, `deploy_token`, `bind_token` call to the NEAR contract). zorsh's `b.nativeEnum` serializes the *position of each variant in declaration order*, not the numeric value, so the JS `ChainKind` declaration order must mirror Rust's.

It didn't. Rust has `…Pol=8, HyperEvm=9, Strk=10, Abs=11` but JS had `…Pol=8, Abs=9, Strk=10` (no `HyperEvm`). `Strk` happened to line up (position 10) but Abstract `fin_transfer` payloads were being decoded by the contract as `HyperEvm`.

## Changes

- `packages/core/src/types.ts`: insert `HyperEvm = 9` between `Pol` and `Strk`; bump `Abs` to `11`. Added a comment explaining why declaration order is load-bearing.
- `packages/core/src/types.ts`: extend `OmniAddress` template literal and `ChainPrefix` union with `hlevm`.
- `packages/core/src/utils/address.ts`: add `hlevm` entries to both prefix maps.
- `packages/core/src/bridge.ts`: map `ChainKind.HyperEvm` to API name `"HlEvm"`; `getContractAddress` throws for `HyperEvm` since no bridge address is configured in the SDK yet.
- `packages/near/tests/chain-kind-schema.test.ts`: new regression test asserting each variant serializes to its expected u8 byte (0–11). Locks the wire format so this can't silently drift again.
- Reference docs updated to include `hlevm:` in `OmniAddress` and `ChainPrefix`.

`EvmChainKind` / `isEvmChain` are intentionally **not** widened to include `HyperEvm` — there's no EVM builder, RPC URL, or chain config for it yet, so leaving it out of the EVM type guard keeps the strict-narrowing contract.

## Compat note

`ChainKind.Abs` changes numeric value from `9` to `11`. Code that compares symbolically (`chain === ChainKind.Abs`) is unaffected; code that hard-coded the literal `9` will need to be updated.