### PR TITLE
fix(btc,near): require zcash rpcUrl, complete deposit example, add parseOmniAddress exhaustiveness

### DIFF
--- a/.changeset/zcash-example-and-exhaustiveness.md
+++ b/.changeset/zcash-example-and-exhaustiveness.md
@@ -1,0 +1,6 @@
+---
+"@omni-bridge/btc": patch
+"@omni-bridge/near": patch
+---
+
+Require an explicit `rpcUrl` when constructing a `BtcBuilder` with `chain: "zcash"` — the previous silent fallback to the Bitcoin RPC default produced confusing downstream errors. Also tighten `parseOmniAddress` in the NEAR storage helper with an exhaustive switch over `ChainPrefix` so future chain additions fail at compile time.

--- a/docs/guides/bitcoin.mdx
+++ b/docs/guides/bitcoin.mdx
@@ -21,10 +21,14 @@ const nearBuilder = createNearBuilder({ network: "mainnet" })
 const near = new Near({ network: "mainnet", privateKey: "ed25519:..." })
 ```
 
-For Zcash, change `chain: "zcash"`:
+For Zcash, change `chain: "zcash"` and supply a Zcash JSON-RPC URL (bake any required auth into the URL itself):
 
 ```typescript
-const zec = createBtcBuilder({ network: "mainnet", chain: "zcash" })
+const zec = createBtcBuilder({
+  network: "mainnet",
+  chain: "zcash",
+  rpcUrl: "https://your-zcash-rpc.example.com",
+})
 ```
 
 ## Deposits: Bitcoin → NEAR
@@ -195,10 +199,14 @@ console.log("Explorer:", `https://mempool.space/tx/${btcTxHash}`)
 
 ## Zcash
 
-Zcash works identically — just change the chain parameter:
+Zcash works identically — change the chain parameter and supply a Zcash JSON-RPC URL (required for `chain: "zcash"`):
 
 ```typescript
-const zec = createBtcBuilder({ network: "mainnet", chain: "zcash" })
+const zec = createBtcBuilder({
+  network: "mainnet",
+  chain: "zcash",
+  rpcUrl: "https://your-zcash-rpc.example.com",
+})
 
 // Deposit
 const { address } = await bridge.getUtxoDepositAddress(

--- a/docs/guides/bitcoin.mdx
+++ b/docs/guides/bitcoin.mdx
@@ -21,7 +21,7 @@ const nearBuilder = createNearBuilder({ network: "mainnet" })
 const near = new Near({ network: "mainnet", privateKey: "ed25519:..." })
 ```
 
-For Zcash, change `chain: "zcash"` and supply a Zcash JSON-RPC URL (bake any required auth into the URL itself):
+For Zcash, change `chain: "zcash"` and supply a Zcash JSON-RPC URL. If your provider's auth fits in the URL path or query string, include it there; otherwise pass `rpcHeaders` directly (e.g. `{ Authorization: "Basic ..." }` or `{ "x-api-key": "..." }`):
 
 ```typescript
 const zec = createBtcBuilder({

--- a/docs/reference/btc.mdx
+++ b/docs/reference/btc.mdx
@@ -99,10 +99,11 @@ const btc = createBtcBuilder({
   chain: "btc",
 })
 
-// Zcash mainnet
+// Zcash mainnet — rpcUrl is required for Zcash (no public default exists)
 const zec = createBtcBuilder({
   network: "mainnet",
   chain: "zcash",
+  rpcUrl: "https://your-zcash-rpc.example.com",
 })
 
 // With custom RPC
@@ -381,7 +382,11 @@ const btcScript = btc.addressToScriptPubkey("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7
 // "0014751e76e8199196d454941c45d1b3a323f1433bd6"
 
 // Zcash t-address
-const zec = createBtcBuilder({ network: "mainnet", chain: "zcash" })
+const zec = createBtcBuilder({
+  network: "mainnet",
+  chain: "zcash",
+  rpcUrl: "https://your-zcash-rpc.example.com",
+})
 const zecScript = zec.addressToScriptPubkey("t1Rv4exT7bqhZqi2j7xz8bUHDMxwosrjADU")
 // "76a914..."
 ```
@@ -1028,7 +1033,7 @@ interface BtcBuilderConfig {
   /** Custom Blockstream API URL */
   apiUrl?: string
   
-  /** Custom RPC URL */
+  /** Custom RPC URL. Required when `chain` is `"zcash"` — there is no public default. */
   rpcUrl?: string
   
   /** RPC authentication headers */

--- a/docs/reference/btc.mdx
+++ b/docs/reference/btc.mdx
@@ -73,7 +73,8 @@ function createBtcBuilder(config: BtcBuilderConfig): BtcBuilder
 
     <ResponseField name="rpcUrl" type="string">
       Bitcoin/Zcash JSON-RPC URL for proof generation.
-      Defaults to `https://bitcoin-rpc.publicnode.com` (mainnet) or `https://bitcoin-testnet-rpc.publicnode.com` (testnet).
+      For Bitcoin, defaults to `https://bitcoin-rpc.publicnode.com` (mainnet) or `https://bitcoin-testnet-rpc.publicnode.com` (testnet).
+      **Required when `chain` is `"zcash"`** — there is no public Zcash default, and the builder will throw at construction if omitted.
     </ResponseField>
 
     <ResponseField name="rpcHeaders" type="Record<string, string>">

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,7 +82,7 @@ Environment variables:
 
 ### 📥 Zcash Deposit (`zcash-deposit.ts`)
 
-Same flow as Bitcoin but uses Zcash-specific RPC. Set `ZCASH_RPC_URL` to a Zcash JSON-RPC endpoint and bake any required auth (e.g. API keys) into the URL itself.
+Same flow as Bitcoin but uses Zcash-specific RPC. Set `ZCASH_RPC_URL` to a Zcash JSON-RPC endpoint — if your provider's auth fits in the URL path or query string, include it there. For HTTP Basic or header-based auth, pass `rpcHeaders` to `createBtcBuilder` directly.
 
 ```bash
 ZCASH_RPC_URL=https://... bun run examples/zcash-deposit.ts

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,10 +82,10 @@ Environment variables:
 
 ### 📥 Zcash Deposit (`zcash-deposit.ts`)
 
-Same flow as Bitcoin but uses Zcash-specific RPC.
+Same flow as Bitcoin but uses Zcash-specific RPC. Set `ZCASH_RPC_URL` to a Zcash JSON-RPC endpoint and bake any required auth (e.g. API keys) into the URL itself.
 
 ```bash
-ZCASH_API_KEY=your_key bun run examples/zcash-deposit.ts
+ZCASH_RPC_URL=https://... bun run examples/zcash-deposit.ts
 ```
 
 ### 📤 Zcash Withdrawal (`zcash-withdraw.ts`)
@@ -93,7 +93,7 @@ ZCASH_API_KEY=your_key bun run examples/zcash-deposit.ts
 Uses ZIP-317 fee calculation automatically.
 
 ```bash
-ZCASH_API_KEY=your_key bun run examples/zcash-withdraw.ts
+ZCASH_RPC_URL=https://... bun run examples/zcash-withdraw.ts
 ```
 
 ## Getting Testnet Funds

--- a/examples/zcash-deposit.ts
+++ b/examples/zcash-deposit.ts
@@ -13,8 +13,10 @@
  * 1. Ensure NEAR credentials are in ~/.near-credentials or set NEAR_PRIVATE_KEY
  * 2. For step 1: Run without TX_HASH to get a deposit address
  * 3. For step 2: Set TX_HASH and VOUT after sending Zcash
- * 4. Set ZCASH_RPC_URL to a Zcash JSON-RPC endpoint (bake auth into the URL
- *    if your provider requires it)
+ * 4. Set ZCASH_RPC_URL to a Zcash JSON-RPC endpoint. If your provider's auth
+ *    fits in the URL path or query string, just include it there. For HTTP
+ *    Basic or header-based auth, pass `rpcHeaders` to `createBtcBuilder`
+ *    directly instead of using this env var.
  *
  * Usage:
  *   Step 1 (get address): ZCASH_RPC_URL=https://... bun run examples/zcash-deposit.ts

--- a/examples/zcash-deposit.ts
+++ b/examples/zcash-deposit.ts
@@ -62,12 +62,6 @@ async function main() {
   console.log(`Account: ${NEAR_ACCOUNT}`)
   console.log(`Network: ${NETWORK}`)
 
-  if (!ZCASH_RPC_URL) {
-    console.error("Set ZCASH_RPC_URL environment variable before running")
-    console.error("(Bake any required auth into the URL itself)")
-    process.exit(1)
-  }
-
   const bridge = createBridge({ network: NETWORK })
   const nearBuilder = createNearBuilder({ network: NETWORK })
   const addresses = getAddresses(NETWORK)
@@ -105,6 +99,12 @@ async function main() {
   console.log("\n=== Step 2: Finalize deposit ===")
   console.log(`TX Hash: ${TX_HASH}`)
   console.log(`VOUT: ${VOUT}`)
+
+  // Zcash RPC is only needed for proof generation in step 2.
+  if (!ZCASH_RPC_URL) {
+    console.error("Set ZCASH_RPC_URL environment variable before finalizing")
+    process.exit(1)
+  }
 
   const zcashBuilder = createBtcBuilder({
     network: NETWORK,

--- a/examples/zcash-deposit.ts
+++ b/examples/zcash-deposit.ts
@@ -161,9 +161,10 @@ async function main() {
 
   try {
     const result = await toNearKitTransaction(near, finalizeTx).send({ waitUntil: "FINAL" })
+    const explorerHost = NETWORK === "mainnet" ? "nearblocks.io" : "testnet.nearblocks.io"
     console.log("\n✓ Deposit finalized!")
     console.log(`  TX Hash: ${result.transaction.hash}`)
-    console.log(`  Explorer: https://testnet.nearblocks.io/txns/${result.transaction.hash}`)
+    console.log(`  Explorer: https://${explorerHost}/txns/${result.transaction.hash}`)
 
     const newBalance = await nearBuilder.getUtxoTokenBalance("zcash", NEAR_ACCOUNT)
     console.log(`\n  Previous balance: ${balance} zatoshis`)

--- a/examples/zcash-deposit.ts
+++ b/examples/zcash-deposit.ts
@@ -10,97 +10,174 @@
  * This example demonstrates the new @omni-bridge packages architecture.
  *
  * Setup:
- * 1. Replace NEAR_ACCOUNT with your testnet account
- * 2. Replace TX_HASH and VOUT with your Zcash transaction details
- * 3. Set ZCASH_API_KEY environment variable
+ * 1. Ensure NEAR credentials are in ~/.near-credentials or set NEAR_PRIVATE_KEY
+ * 2. For step 1: Run without TX_HASH to get a deposit address
+ * 3. For step 2: Set TX_HASH and VOUT after sending Zcash
+ * 4. Set ZCASH_RPC_URL to a Zcash JSON-RPC endpoint (bake auth into the URL
+ *    if your provider requires it)
  *
- * Usage: ZCASH_API_KEY=your_key bun run examples/zcash-deposit.ts
+ * Usage:
+ *   Step 1 (get address): ZCASH_RPC_URL=https://... bun run examples/zcash-deposit.ts
+ *   Step 2 (finalize):    ZCASH_RPC_URL=https://... TX_HASH=abc123 VOUT=0 bun run examples/zcash-deposit.ts
  */
 
 import { createBtcBuilder } from "@omni-bridge/btc"
 import { ChainKind, createBridge, getAddresses, type Network } from "@omni-bridge/core"
+import { createNearBuilder, toNearKitTransaction } from "@omni-bridge/near"
 import { Near } from "near-kit"
 
-// Configuration - Replace with your values
-const NEAR_ACCOUNT = "bridge-sdk-test.testnet"
-const NETWORK: Network = "testnet"
-const ZCASH_API_KEY = process.env.ZCASH_API_KEY ?? ""
+// Configuration - can be overridden via environment variables
+const NEAR_ACCOUNT = process.env.NEAR_ACCOUNT ?? "omni-sdk-test.testnet"
+const NETWORK: Network = (process.env.NETWORK as Network) ?? "testnet"
+const ZCASH_RPC_URL = process.env.ZCASH_RPC_URL ?? ""
 
-// Step 2 configuration - Add these after sending Zcash
-const TX_HASH = "" // Your Zcash transaction hash (leave empty for step 1 only)
-const VOUT = 0 // Output index (usually 0 or 1)
+// Step 2 configuration - set via environment variables
+const TX_HASH = process.env.TX_HASH ?? ""
+const VOUT = Number.parseInt(process.env.VOUT ?? "0", 10)
+
+async function createNearInstance(): Promise<Near> {
+  const privateKey = process.env.NEAR_PRIVATE_KEY
+
+  if (privateKey) {
+    return new Near({
+      network: NETWORK,
+      privateKey: privateKey as `ed25519:${string}`,
+      defaultSignerId: NEAR_ACCOUNT,
+    })
+  }
+
+  const { FileKeyStore } = await import("near-kit/keys/file")
+  const os = await import("node:os")
+  const path = await import("node:path")
+
+  return new Near({
+    network: NETWORK,
+    keyStore: new FileKeyStore(path.join(os.homedir(), ".near-credentials"), NETWORK),
+    defaultSignerId: NEAR_ACCOUNT,
+  })
+}
 
 async function main() {
   console.log("Zcash Deposit Example (New SDK)")
+  console.log(`Account: ${NEAR_ACCOUNT}`)
+  console.log(`Network: ${NETWORK}`)
 
-  if (!ZCASH_API_KEY) {
-    console.error("Set ZCASH_API_KEY environment variable before running")
+  if (!ZCASH_RPC_URL) {
+    console.error("Set ZCASH_RPC_URL environment variable before running")
+    console.error("(Bake any required auth into the URL itself)")
     process.exit(1)
   }
 
-  // Initialize the Bridge for API access
   const bridge = createBridge({ network: NETWORK })
+  const nearBuilder = createNearBuilder({ network: NETWORK })
   const addresses = getAddresses(NETWORK)
 
-  // Initialize near-kit for NEAR interactions
-  const near = new Near({ network: NETWORK })
+  // Get connector config
+  const config = await nearBuilder.getUtxoConnectorConfig("zcash")
+  console.log(`\nConnector: ${addresses.zcash.zcashConnector}`)
+  console.log(`Min deposit: ${config.min_deposit_amount} zatoshis`)
 
-  // Get connector config to check minimum deposit
-  const connectorConfig = await near.view<{
-    min_deposit_amount: string
-    deposit_bridge_fee: { fee_min: string }
-  }>(addresses.zcash.zcashConnector, "get_config", {})
+  // Check current balance
+  const balance = await nearBuilder.getUtxoTokenBalance("zcash", NEAR_ACCOUNT)
+  console.log(`Current nZEC balance: ${balance} zatoshis`)
 
-  if (connectorConfig) {
-    const minDeposit =
-      BigInt(connectorConfig.min_deposit_amount) +
-      BigInt(connectorConfig.deposit_bridge_fee.fee_min)
-    console.log(`Minimum deposit: ${minDeposit} zatoshis`)
-  }
-
-  // Step 1: Generate Zcash deposit address using the new Bridge API
-  console.log("\nStep 1: Generate deposit address")
-
-  const depositResult = await bridge.getUtxoDepositAddress(ChainKind.Zcash, NEAR_ACCOUNT)
-
-  console.log(`Send Zcash to: ${depositResult.address}`)
-  console.log(`Chain: ${depositResult.chain}`)
-  console.log(`Recipient: ${depositResult.recipient}`)
-
-  // Check if user has provided transaction details
+  // Step 1: Generate deposit address if no TX_HASH provided
   if (!TX_HASH) {
-    console.log("\nNext steps:")
+    console.log("\n=== Step 1: Generate deposit address ===")
+
+    const depositResult = await bridge.getUtxoDepositAddress(ChainKind.Zcash, NEAR_ACCOUNT)
+
+    console.log(`\nSend Zcash to: ${depositResult.address}`)
+    console.log(`Chain: ${depositResult.chain}`)
+    console.log(`Recipient: ${depositResult.recipient}`)
+
+    console.log("\n=== Next steps ===")
     console.log("1. Send Zcash to the address above")
     console.log("2. Wait for Zcash network confirmation")
-    console.log("3. Update TX_HASH and VOUT in this script")
-    console.log("4. Run script again to finalize")
+    console.log("3. Run again with TX_HASH and VOUT:")
+    console.log(
+      "   ZCASH_RPC_URL=<url> TX_HASH=<hash> VOUT=<index> bun run examples/zcash-deposit.ts",
+    )
     return
   }
 
-  // Step 2: Get deposit proof and finalize on NEAR
-  console.log("\nStep 2: Finalize deposit")
-  console.log(`Using TX: ${TX_HASH}`)
+  // Step 2: Finalize deposit
+  console.log("\n=== Step 2: Finalize deposit ===")
+  console.log(`TX Hash: ${TX_HASH}`)
+  console.log(`VOUT: ${VOUT}`)
 
-  // Create Zcash builder for proof generation
-  // Note: Zcash uses the same builder with chain: "zcash" config
   const zcashBuilder = createBtcBuilder({
     network: NETWORK,
     chain: "zcash",
-    rpcHeaders: { "x-api-key": ZCASH_API_KEY },
+    rpcUrl: ZCASH_RPC_URL,
   })
 
-  try {
-    // Get the deposit proof from the Zcash blockchain
-    const proof = await zcashBuilder.getDepositProof(TX_HASH, VOUT)
-    console.log(`Proof generated for ${proof.amount} zatoshis`)
+  // Get the deposit proof
+  console.log("\nFetching deposit proof from Zcash network...")
+  let proof: Awaited<ReturnType<typeof zcashBuilder.getDepositProof>>
 
-    console.log("\nDeposit proof ready!")
-    console.log("To finalize, call verify_deposit on the Zcash connector contract")
-    console.log(`Contract: ${addresses.zcash.zcashConnector}`)
+  try {
+    proof = await zcashBuilder.getDepositProof(TX_HASH, VOUT)
+    console.log(`✓ Proof generated for ${proof.amount} zatoshis`)
+    console.log(`  Block hash: ${proof.tx_block_blockhash}`)
+    console.log(`  TX index: ${proof.tx_index}`)
+    console.log(`  Merkle proof: ${proof.merkle_proof.length} hashes`)
   } catch (error) {
-    console.log("Proof generation failed:")
-    console.log((error as Error).message)
-    console.log("\nMake sure the transaction is confirmed on the Zcash network")
+    console.error("✗ Failed to get deposit proof:")
+    console.error((error as Error).message)
+    console.log("\nMake sure:")
+    console.log("- The transaction is confirmed on the Zcash network")
+    console.log("- The TX_HASH and VOUT are correct")
+    console.log("- ZCASH_RPC_URL is reachable and accepts JSON-RPC")
+    return
+  }
+
+  // Check minimum deposit
+  if (proof.amount < BigInt(config.min_deposit_amount)) {
+    console.error(
+      `\n✗ Deposit amount ${proof.amount} is below minimum ${config.min_deposit_amount}`,
+    )
+    return
+  }
+
+  // Build the finalization transaction
+  console.log("\nBuilding finalization transaction...")
+  const finalizeTx = nearBuilder.buildUtxoDepositFinalization({
+    chain: "zcash",
+    depositMsg: {
+      recipient_id: NEAR_ACCOUNT,
+    },
+    txBytes: proof.tx_bytes,
+    vout: VOUT,
+    txBlockBlockhash: proof.tx_block_blockhash,
+    txIndex: proof.tx_index,
+    merkleProof: proof.merkle_proof,
+    signerId: NEAR_ACCOUNT,
+  })
+
+  // Send the transaction
+  console.log("Sending verify_deposit transaction...")
+  const near = await createNearInstance()
+
+  try {
+    const result = await toNearKitTransaction(near, finalizeTx).send({ waitUntil: "FINAL" })
+    console.log("\n✓ Deposit finalized!")
+    console.log(`  TX Hash: ${result.transaction.hash}`)
+    console.log(`  Explorer: https://testnet.nearblocks.io/txns/${result.transaction.hash}`)
+
+    const newBalance = await nearBuilder.getUtxoTokenBalance("zcash", NEAR_ACCOUNT)
+    console.log(`\n  Previous balance: ${balance} zatoshis`)
+    console.log(`  New balance: ${newBalance} zatoshis`)
+    console.log(`  Deposited: ${newBalance - balance} zatoshis`)
+  } catch (error) {
+    console.error("\n✗ Finalization failed:")
+    console.error((error as Error).message)
+
+    if ((error as Error).message.includes("already")) {
+      console.log("\nThe deposit may have already been finalized by relayers.")
+      const currentBalance = await nearBuilder.getUtxoTokenBalance("zcash", NEAR_ACCOUNT)
+      console.log(`Current balance: ${currentBalance} zatoshis`)
+    }
   }
 }
 

--- a/examples/zcash-withdraw.ts
+++ b/examples/zcash-withdraw.ts
@@ -14,10 +14,11 @@
  * Setup:
  * 1. Replace NEAR_ACCOUNT with your testnet account
  * 2. Replace ZCASH_ADDRESS with your Zcash testnet address
- * 3. Set ZCASH_API_KEY environment variable
+ * 3. Set ZCASH_RPC_URL to a Zcash JSON-RPC endpoint (bake auth into the URL
+ *    if your provider requires it)
  * 4. Ensure you have nZEC balance
  *
- * Usage: ZCASH_API_KEY=your_key bun run examples/zcash-withdraw.ts
+ * Usage: ZCASH_RPC_URL=https://... bun run examples/zcash-withdraw.ts
  */
 
 import { createBtcBuilder, getZcashScript } from "@omni-bridge/btc"
@@ -28,14 +29,15 @@ import { Near } from "near-kit"
 const NEAR_ACCOUNT = "bridge-sdk-test.testnet"
 const ZCASH_ADDRESS = "tmXxJxBHuNhDD5nca3uCQwcSGgsJ7qLfvWg"
 const NETWORK: Network = "testnet"
-const ZCASH_API_KEY = process.env.ZCASH_API_KEY ?? ""
+const ZCASH_RPC_URL = process.env.ZCASH_RPC_URL ?? ""
 
 async function main() {
   console.log("Zcash Withdrawal Example (New SDK)")
   console.log(`Withdrawing from ${NEAR_ACCOUNT} to ${ZCASH_ADDRESS}`)
 
-  if (!ZCASH_API_KEY) {
-    console.error("Set ZCASH_API_KEY environment variable before running")
+  if (!ZCASH_RPC_URL) {
+    console.error("Set ZCASH_RPC_URL environment variable before running")
+    console.error("(Bake any required auth into the URL itself)")
     process.exit(1)
   }
 
@@ -44,7 +46,7 @@ async function main() {
   const zcashBuilder = createBtcBuilder({
     network: NETWORK,
     chain: "zcash",
-    rpcHeaders: { "x-api-key": ZCASH_API_KEY },
+    rpcUrl: ZCASH_RPC_URL,
   })
   const addresses = getAddresses(NETWORK)
   const near = new Near({ network: NETWORK })

--- a/examples/zcash-withdraw.ts
+++ b/examples/zcash-withdraw.ts
@@ -14,8 +14,10 @@
  * Setup:
  * 1. Replace NEAR_ACCOUNT with your testnet account
  * 2. Replace ZCASH_ADDRESS with your Zcash testnet address
- * 3. Set ZCASH_RPC_URL to a Zcash JSON-RPC endpoint (bake auth into the URL
- *    if your provider requires it)
+ * 3. Set ZCASH_RPC_URL to a Zcash JSON-RPC endpoint. If your provider's auth
+ *    fits in the URL path or query string, just include it there. For HTTP
+ *    Basic or header-based auth, pass `rpcHeaders` to `createBtcBuilder`
+ *    directly instead of using this env var.
  * 4. Ensure you have nZEC balance
  *
  * Usage: ZCASH_RPC_URL=https://... bun run examples/zcash-withdraw.ts

--- a/packages/btc/README.md
+++ b/packages/btc/README.md
@@ -138,7 +138,7 @@ interface BtcBuilderConfig {
   network: "mainnet" | "testnet"
   chain?: "btc" | "zcash" // defaults to "btc"
   apiUrl?: string // Blockstream API URL (optional)
-  rpcUrl?: string // Bitcoin RPC URL for proofs (optional)
+  rpcUrl?: string // RPC URL for proofs — required when chain is "zcash"
   rpcHeaders?: Record<string, string> // Custom RPC headers (optional)
 }
 ```

--- a/packages/btc/src/builder.ts
+++ b/packages/btc/src/builder.ts
@@ -138,6 +138,14 @@ class BtcBuilderImpl implements BtcBuilder {
     this.apiUrl = config.apiUrl ?? DEFAULT_API_URLS[config.network]
 
     const chainKind = this.chain === "zcash" ? ChainKind.Zcash : ChainKind.Btc
+    // No sensible public Zcash RPC default exists, and silently falling back
+    // to the Bitcoin default would fail later with a confusing RPC-method
+    // error. Force callers to bring their own URL for Zcash.
+    if (this.chain === "zcash" && !config.rpcUrl) {
+      throw new Error(
+        "Zcash builder requires an explicit rpcUrl — pass `rpcUrl` in BtcBuilderConfig",
+      )
+    }
     const rpcUrl = config.rpcUrl ?? DEFAULT_RPC_URLS[config.network]
 
     this.rpc = new UtxoRpcClient({

--- a/packages/btc/tests/builder.test.ts
+++ b/packages/btc/tests/builder.test.ts
@@ -142,4 +142,22 @@ describe("BtcBuilder", () => {
       expect(() => builder.addressToScriptPubkey("invalid_address")).toThrow()
     })
   })
+
+  describe("zcash rpcUrl requirement", () => {
+    it("throws when chain is zcash and no rpcUrl is provided", () => {
+      expect(() => createBtcBuilder({ network: "mainnet", chain: "zcash" })).toThrow(
+        /Zcash builder requires an explicit rpcUrl/,
+      )
+    })
+
+    it("accepts an explicit rpcUrl for zcash", () => {
+      expect(() =>
+        createBtcBuilder({
+          network: "mainnet",
+          chain: "zcash",
+          rpcUrl: "https://example.com/zcash",
+        }),
+      ).not.toThrow()
+    })
+  })
 })

--- a/packages/btc/tests/zcash.test.ts
+++ b/packages/btc/tests/zcash.test.ts
@@ -4,7 +4,11 @@ import type { UTXO } from "../src/types.js"
 import * as zcashUtils from "../src/zcash.js"
 
 describe("ZcashBuilder", () => {
-  const builder = createBtcBuilder({ network: "testnet", chain: "zcash" })
+  const builder = createBtcBuilder({
+    network: "testnet",
+    chain: "zcash",
+    rpcUrl: "https://example.com/zcash",
+  })
 
   describe("buildWithdrawalPlan", () => {
     it("creates plan with change output when needed", () => {

--- a/packages/near/src/storage.ts
+++ b/packages/near/src/storage.ts
@@ -3,6 +3,7 @@
  */
 
 import { sha256 } from "@noble/hashes/sha2.js"
+import type { ChainPrefix } from "@omni-bridge/core"
 import { base58, hex } from "@scure/base"
 import { b } from "@zorsh/zorsh"
 
@@ -85,7 +86,10 @@ export function calculateStorageAccountId(transferMessage: TransferMessageForSto
 
 function parseOmniAddress(token: string) {
   const parts = token.split(":", 2)
-  const chain = parts[0]
+  // Cast through ChainPrefix so the switch below is exhaustive at compile
+  // time — adding a new variant to ChainPrefix without a case here will
+  // trip the `never` assignment in the default branch.
+  const chain = parts[0] as ChainPrefix
   const address = parts[1]
   if (!address) {
     throw new Error(`Invalid token address format: ${token}`)
@@ -128,7 +132,9 @@ function parseOmniAddress(token: string) {
       return { Strk: decodeStrk(address) }
     case "abs":
       return { Abs: decodeHex(address) }
-    default:
-      throw new Error(`Unknown chain: ${chain}`)
+    default: {
+      const _exhaustive: never = chain
+      throw new Error(`Unknown chain: ${_exhaustive as string}`)
+    }
   }
 }


### PR DESCRIPTION
Two pieces of feedback from the Slack thread on zcash:

1. The `rpcHeaders: { "x-api-key": ... }` pattern in the example is confusing — it baked Tatum-style auth into the docs. Swapped for a plain `ZCASH_RPC_URL` env var; users bake auth into the URL themselves.
2. The example stopped at "proof generated, now go call verify_deposit yourself." Now it actually finalizes the deposit via `buildUtxoDepositFinalization` + `toNearKitTransaction`, same as the bitcoin example.

Also bundled in: `BtcBuilder` now throws when `chain: "zcash"` is passed without an `rpcUrl` (instead of silently falling back to the Bitcoin RPC default), and `parseOmniAddress` in the NEAR storage helper is now exhaustive over `ChainPrefix` so future chain additions trip a compile error.

Docs and READMEs updated to match.

## Test plan

- [x] `bun run typecheck`, `lint`, `build`
- [x] Unit tests pass (`packages/btc/`, `packages/near/`)
- [ ] Smoke-test `examples/zcash-deposit.ts` end-to-end on testnet