### PR TITLE
fix(core)!: unify v4 transfer spelling to British 'initialised'

### DIFF
--- a/.changeset/v4-british-spelling.md
+++ b/.changeset/v4-british-spelling.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/core": minor
+---
+
+BREAKING: unify the v4 transfer shape to British spelling, matching the rest of the fields — the `initialized` field is now `initialised`, and the `"Initialized"` status is now `"Initialised"` (alongside `finalised`, `FastFinalisedOnNear`, etc.). Requires an indexer deployment that serves the renamed field.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -141,7 +141,7 @@ const api = new BridgeAPI("mainnet")
 const status = await api.getTransferStatus({ transactionHash: hash })
 
 console.log("Current status:", status[status.length - 1])
-// "Initialized" → "Signed" → "FinalisedOnNear" → "Finalised"
+// "Initialised" → "Signed" → "FinalisedOnNear" → "Finalised"
 ```
 
 See [Tracking Transfers](/guides/tracking) for polling patterns and status meanings.

--- a/docs/guides/advanced/manual-finalization.mdx
+++ b/docs/guides/advanced/manual-finalization.mdx
@@ -50,7 +50,7 @@ if (statuses.includes("Signed")) {
 }
 ```
 
-For Ethereum → NEAR specifically, you need to wait for the light client to sync the block (check `Initialized` status and wait ~15-20 min).
+For Ethereum → NEAR specifically, you need to wait for the light client to sync the block (check `Initialised` status and wait ~15-20 min).
 
 ## From NEAR to EVM
 

--- a/docs/guides/tracking.mdx
+++ b/docs/guides/tracking.mdx
@@ -49,7 +49,7 @@ Transfers move through these statuses:
 
 | Status | Meaning |
 |--------|---------|
-| `Initialized` | Transfer submitted on source chain |
+| `Initialised` | Transfer submitted on source chain |
 | `Signed` | MPC signature obtained |
 | `FinalisedOnNear` | Finalized on NEAR |
 | `Finalised` | Finalized on destination chain |
@@ -66,17 +66,17 @@ For fast transfers (relayer fronts liquidity):
 
 **Standard (with relayer fees):**
 ```
-Initialized → Signed → FinalisedOnNear → Finalised → Settled
+Initialised → Signed → FinalisedOnNear → Finalised → Settled
 ```
 
 **Fast transfer:**
 ```
-Initialized → FastFinalisedOnNear → FastFinalised → ... → Settled
+Initialised → FastFinalisedOnNear → FastFinalised → ... → Settled
 ```
 
 **Manual (no fees):**
 ```
-Initialized → Signed → (you finalize manually)
+Initialised → Signed → (you finalize manually)
 ```
 
 ## Polling Pattern
@@ -127,8 +127,8 @@ if (transfer) {
 }
 
 // Transaction hashes at each stage
-if (transfer?.initialized) {
-  console.log("Source TX:", transfer.initialized.transaction_hash)
+if (transfer?.initialised) {
+  console.log("Source TX:", transfer.initialised.transaction_hash)
 }
 if (transfer?.finalised) {
   console.log("Destination TX:", transfer.finalised.transaction_hash)
@@ -182,7 +182,7 @@ if (statuses.includes("Signed")) {
 For EVM → NEAR (Ethereum mainnet only), you need to wait for the light client instead:
 
 ```typescript
-if (statuses.includes("Initialized")) {
+if (statuses.includes("Initialised")) {
   // Wait ~15-20 minutes for NEAR light client to sync
   // Then generate Merkle proof and finalize
 }

--- a/docs/reference/core.mdx
+++ b/docs/reference/core.mdx
@@ -576,7 +576,7 @@ api.getTransferStatus(options: TransferLookupParams): Promise<TransferStatus[]>
   initiated more than one.
 
   Known values:
-  - `"Initialized"` - Transfer initiated on source chain
+  - `"Initialised"` - Transfer initiated on source chain
   - `"Signed"` - MPC signature obtained
   - `"FastFinalisedOnNear"` - Fast finalized on NEAR
   - `"FinalisedOnNear"` - Finalized on NEAR
@@ -771,7 +771,7 @@ Same as `getTransferStatus`.
       Current transfer status — no separate status call needed.
     </ResponseField>
 
-    <ResponseField name="initialized" type="TransactionRef | null">
+    <ResponseField name="initialised" type="TransactionRef | null">
       Transaction that initiated the transfer.
     </ResponseField>
 

--- a/e2e/shared/assertions.ts
+++ b/e2e/shared/assertions.ts
@@ -11,7 +11,7 @@ export class TransferAssertions {
   async validateTransferStatus(
     originChain: "Near" | "Eth" | "Sol" | "Arb" | "Base",
     originNonce: number,
-    expectedStatus?: "initialized" | "signed" | "finalised",
+    expectedStatus?: "initialised" | "signed" | "finalised",
   ): Promise<void> {
     const statuses = await this.api.getTransferStatus({
       originChain,
@@ -48,7 +48,7 @@ export class TransferAssertions {
     }
 
     expect(transfer).toHaveProperty("transfer_id")
-    expect(transfer).toHaveProperty("initialized")
+    expect(transfer).toHaveProperty("initialised")
     expect(transfer).toHaveProperty("status")
 
     // Verify the transfer has progressed beyond initialization

--- a/examples/eth-to-near.ts
+++ b/examples/eth-to-near.ts
@@ -138,8 +138,8 @@ async function main() {
 
         const transfers = await api.getTransfer({ transactionHash: transferHash })
         const transfer = transfers[0]
-        if (transfer?.initialized) {
-          console.log(`  Origin TX: ${transfer.initialized.transaction_hash}`)
+        if (transfer?.initialised) {
+          console.log(`  Origin TX: ${transfer.initialised.transaction_hash}`)
         }
         if (transfer?.finalised) {
           console.log(`  Destination TX: ${transfer.finalised.transaction_hash}`)

--- a/examples/near-to-eth.ts
+++ b/examples/near-to-eth.ts
@@ -146,8 +146,8 @@ async function main() {
           transactionHash: result.transaction.hash,
         })
         const transfer = transfers[0]
-        if (transfer?.initialized) {
-          console.log(`  Origin TX: ${transfer.initialized.transaction_hash}`)
+        if (transfer?.initialised) {
+          console.log(`  Origin TX: ${transfer.initialised.transaction_hash}`)
         }
         if (transfer?.finalised) {
           console.log(`  Destination TX: ${transfer.finalised.transaction_hash}`)

--- a/examples/solana-to-near.ts
+++ b/examples/solana-to-near.ts
@@ -131,8 +131,8 @@ async function main() {
 
         const transfers = await api.getTransfer({ transactionHash: signature })
         const transfer = transfers[0]
-        if (transfer?.initialized) {
-          console.log(`  Origin TX: ${transfer.initialized.transaction_hash}`)
+        if (transfer?.initialised) {
+          console.log(`  Origin TX: ${transfer.initialised.transaction_hash}`)
         }
         if (transfer?.finalised) {
           console.log(`  Destination TX: ${transfer.finalised.transaction_hash}`)

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -26,7 +26,7 @@ const ChainSchema = z.enum([
 export type Chain = z.infer<typeof ChainSchema>
 
 const KNOWN_TRANSFER_STATUSES = [
-  "Initialized",
+  "Initialised",
   "Signed",
   "FastFinalisedOnNear",
   "FinalisedOnNear",
@@ -175,7 +175,7 @@ const TransferSchema = z.object({
   msg: orNull(z.string()),
   destination_nonce: orNull(z.number().int().min(0)),
   status: TransferStatusSchema,
-  initialized: orNull(TransactionRefSchema),
+  initialised: orNull(TransactionRefSchema),
   signed: z.array(TransactionRefSchema),
   fast_finalised_on_near: orNull(TransactionRefSchema),
   finalised_on_near: orNull(TransactionRefSchema),

--- a/packages/core/tests/api.test.ts
+++ b/packages/core/tests/api.test.ts
@@ -18,8 +18,8 @@ const mockTransfer = {
   fee: "1000",
   native_fee: "2000",
   msg: "test transfer",
-  status: "Initialized",
-  initialized: {
+  status: "Initialised",
+  initialised: {
     transaction_hash: "0x123...",
     chain: "Eth",
     timestamp_seconds: 1234567890,
@@ -49,8 +49,8 @@ const mockStarknetTransfer = {
   transfer_id: { type: "nonce", chain: "Strk", nonce: 456 },
   source_chain: "Strk",
   destination_chain: "Near",
-  status: "Initialized",
-  initialized: {
+  status: "Initialised",
+  initialised: {
     transaction_hash: "0xstarknettx",
     chain: "Strk",
     timestamp_seconds: 1730000000,
@@ -115,7 +115,7 @@ const mockBtcAddress = {
 
 const restHandlers = [
   http.get(`${BASE_URL}/api/v4/transfers/transfer/status`, () => {
-    return HttpResponse.json({ statuses: ["Initialized"] })
+    return HttpResponse.json({ statuses: ["Initialised"] })
   }),
   http.get(`${BASE_URL}/api/v4/transfers/transfer`, () => {
     return HttpResponse.json({ transfers: [mockTransfer] })
@@ -143,17 +143,17 @@ describe("BridgeAPI", () => {
   describe("getTransferStatus", () => {
     it("should fetch transfer status successfully", async () => {
       const status = await api.getTransferStatus({ originChain: "Eth", originNonce: 123 })
-      expect(status).toEqual(["Initialized"])
+      expect(status).toEqual(["Initialised"])
     })
 
     it("should handle transaction hash parameter", async () => {
       const status = await api.getTransferStatus({ transactionHash: "0x123..." })
-      expect(status).toEqual(["Initialized"])
+      expect(status).toEqual(["Initialised"])
     })
 
     it("should accept new chain enums", async () => {
       const status = await api.getTransferStatus({ originChain: "HlEvm", originNonce: 123 })
-      expect(status).toEqual(["Initialized"])
+      expect(status).toEqual(["Initialised"])
     })
 
     it("should return Settled status", async () => {


### PR DESCRIPTION
## What

The v4 transfer shape mixed American and British spelling: `initialized` / `"Initialized"` next to `finalised`, `fast_finalised_on_near`, `FastFinalisedOnNear`, etc. This renames the field to `initialised` and the status to `"Initialised"`, matching the indexer-side unification on the [`fix/unify-v4-spelling`](https://github.com/Near-One/bridge-indexer-rs/tree/fix/unify-v4-spelling) branch of bridge-indexer-rs.

## Changes

- `TransferSchema` field `initialized` → `initialised`; `KNOWN_TRANSFER_STATUSES` `"Initialized"` → `"Initialised"`
- Tests, examples, and e2e assertions updated
- Docs (getting-started, tracking guide, manual-finalization, core reference) updated
- Changeset: `minor` bump for `@omni-bridge/core`, marked BREAKING

## Deployment note

Must not be released before the indexer serves the renamed field: the schema normalizes an absent `initialised` to `null`, so against an old indexer transfer lookups would silently return null-ish stages instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)