### PR TITLE
fix(core)!: rename source_chain to origin_chain in v4 transfer shape

### DIFF
--- a/.changeset/v4-origin-chain.md
+++ b/.changeset/v4-origin-chain.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/core": minor
+---
+
+BREAKING: rename `source_chain` to `origin_chain` in the v4 transfer shape, matching the `originChain` lookup param and protocol vocabulary. Requires an indexer deployment that serves the renamed field.

--- a/docs/reference/core.mdx
+++ b/docs/reference/core.mdx
@@ -727,7 +727,7 @@ Same as `getTransferStatus`.
       hasn't been indexed yet.
     </ResponseField>
 
-    <ResponseField name="source_chain" type="Chain | null">
+    <ResponseField name="origin_chain" type="Chain | null">
       Source chain of the transfer.
     </ResponseField>
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -164,7 +164,7 @@ export type UtxoMeta = z.infer<typeof UtxoMetaSchema>
 
 const TransferSchema = z.object({
   transfer_id: orNull(TransferIdSchema),
-  source_chain: orNull(ChainSchema),
+  origin_chain: orNull(ChainSchema),
   destination_chain: orNull(ChainSchema),
   sender: orNull(z.string()),
   recipient: orNull(z.string()),

--- a/packages/core/tests/api.test.ts
+++ b/packages/core/tests/api.test.ts
@@ -9,7 +9,7 @@ const BASE_URL = "https://testnet.api.bridge.nearone.org"
 // Mock data
 const mockTransfer = {
   transfer_id: { type: "nonce", chain: "Eth", nonce: 123 },
-  source_chain: "Eth",
+  origin_chain: "Eth",
   destination_chain: "Near",
   sender: "eth:0xsender",
   recipient: "near:recipient.near",
@@ -47,7 +47,7 @@ const normalizedTransfer = {
 
 const mockStarknetTransfer = {
   transfer_id: { type: "nonce", chain: "Strk", nonce: 456 },
-  source_chain: "Strk",
+  origin_chain: "Strk",
   destination_chain: "Near",
   status: "Initialised",
   initialised: {


### PR DESCRIPTION
## What

The v4 lookup param is `originChain`/`originNonce` (protocol `TransferId` vocabulary), but the response field was `source_chain`. Renames the response field to `origin_chain`, matching the indexer-side rename in Near-One/bridge-indexer-rs#408.

## Changes

- `TransferSchema.source_chain` → `origin_chain`
- Test fixtures and core reference docs updated
- Own changeset (`minor`, BREAKING)

## Deployment

Same coupling as #491: must not be released before the indexer serves the renamed field (`orNull` would silently normalize the missing field to `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)