### PR TITLE
feat: externalId in calculateStorageAccountId

### DIFF
--- a/.changeset/external-id-for-virtual-id-calculation.md
+++ b/.changeset/external-id-for-virtual-id-calculation.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/near": minor
+---
+
+`calculateStorageAccountId` accepts an optional second `externalId` argument, mixed into the hash so otherwise-identical transfers can derive distinct storage accounts. Limited to 64 UTF-8 bytes, matching the Rust `MAX_EXTERNAL_ID_LEN`; longer values throw.

--- a/packages/near/src/storage.ts
+++ b/packages/near/src/storage.ts
@@ -57,6 +57,9 @@ export type TransferMessageForStorage = {
   msg: string
 }
 
+// Matches `MAX_EXTERNAL_ID_LEN` in the Rust omni-bridge repo (near/omni-types/src/lib.rs).
+const MAX_EXTERNAL_ID_LEN = 64
+
 /**
  * Calculates the storage account ID for a transfer message
  *
@@ -66,9 +69,14 @@ export type TransferMessageForStorage = {
  * 3. Converts the hash to hex to create an implicit NEAR account ID
  *
  * @param transferMessage - The transfer message data with bigint amounts
+ * @param externalId - Optional caller-supplied identifier mixed into the hash so otherwise-identical
+ *   transfers derive distinct storage accounts. Limited to `MAX_EXTERNAL_ID_LEN` (64) UTF-8 bytes.
  * @returns The calculated storage account ID as a hex string
  */
-export function calculateStorageAccountId(transferMessage: TransferMessageForStorage): string {
+export function calculateStorageAccountId(
+  transferMessage: TransferMessageForStorage,
+  externalId?: string,
+): string {
   const serializedData = TransferMessageStorageAccountSchema.serialize({
     token: parseOmniAddress(transferMessage.token),
     amount: transferMessage.amount,
@@ -81,8 +89,18 @@ export function calculateStorageAccountId(transferMessage: TransferMessageForSto
     msg: transferMessage.msg,
   })
 
-  const hash = sha256(serializedData)
-  return hex.encode(hash)
+  const hash = sha256.create().update(serializedData)
+  if (externalId) {
+    const externalIdBytes = new TextEncoder().encode(externalId)
+    if (externalIdBytes.length > MAX_EXTERNAL_ID_LEN) {
+      throw new Error(
+        `externalId exceeds ${MAX_EXTERNAL_ID_LEN} bytes: got ${externalIdBytes.length} bytes`,
+      )
+    }
+    hash.update(externalIdBytes)
+  }
+
+  return hex.encode(hash.digest())
 }
 
 function parseOmniAddress(token: string) {

--- a/packages/near/tests/storage.test.ts
+++ b/packages/near/tests/storage.test.ts
@@ -228,4 +228,79 @@ describe("calculateStorageAccountId", () => {
     expect(results.every((result) => result === firstResult)).toBe(true)
     expect(firstResult).toMatch(/^[a-f0-9]{64}$/)
   })
+
+  describe("externalId", () => {
+    const transferMessage = {
+      token: "near:token.near" as const,
+      amount: 1000000000000000000000000n,
+      recipient: "eth:0x742d35Cc6734C0532925a3b8D84f8FBf4D7bE86f" as const,
+      fee: {
+        fee: 100000000000000000000000n,
+        native_fee: 1000000000000000000000n,
+      },
+      sender: "near:sender.near" as const,
+      msg: "test transfer",
+    }
+
+    it("changes the account ID compared to omitting externalId", () => {
+      const withoutExternalId = calculateStorageAccountId(transferMessage)
+      const withExternalId = calculateStorageAccountId(transferMessage, "external-id")
+
+      expect(withExternalId).not.toBe(withoutExternalId)
+      expect(withExternalId).toMatch(/^[a-f0-9]{64}$/)
+    })
+
+    it("treats an empty string the same as omitting externalId", () => {
+      const withoutExternalId = calculateStorageAccountId(transferMessage)
+      const withEmptyExternalId = calculateStorageAccountId(transferMessage, "")
+
+      expect(withEmptyExternalId).toBe(withoutExternalId)
+    })
+
+    it("is deterministic for the same externalId", () => {
+      const accountId1 = calculateStorageAccountId(transferMessage, "external-id")
+      const accountId2 = calculateStorageAccountId(transferMessage, "external-id")
+
+      expect(accountId1).toBe(accountId2)
+    })
+
+    it("produces different account IDs for different externalId values", () => {
+      const accountId1 = calculateStorageAccountId(transferMessage, "external-id-1")
+      const accountId2 = calculateStorageAccountId(transferMessage, "external-id-2")
+
+      expect(accountId1).not.toBe(accountId2)
+    })
+
+    it("handles unicode externalId values", () => {
+      const accountId = calculateStorageAccountId(transferMessage, "🚀 external 特殊文字")
+
+      expect(accountId).toMatch(/^[a-f0-9]{64}$/)
+    })
+
+    it("accepts an externalId at exactly the 64-byte limit", () => {
+      const externalId = "a".repeat(64)
+      const accountId = calculateStorageAccountId(transferMessage, externalId)
+
+      expect(accountId).toMatch(/^[a-f0-9]{64}$/)
+    })
+
+    it("throws when externalId exceeds the 64-byte limit", () => {
+      const externalId = "a".repeat(65)
+
+      expect(() => calculateStorageAccountId(transferMessage, externalId)).toThrow(
+        /externalId exceeds 64 bytes/,
+      )
+    })
+
+    it("enforces the limit on UTF-8 byte length, not string length", () => {
+      // Each "🚀" is 2 UTF-16 code units but 4 UTF-8 bytes, so 17 copies are
+      // only 34 code units long yet 68 bytes — over the limit.
+      const externalId = "🚀".repeat(17)
+
+      expect(externalId.length).toBeLessThan(64)
+      expect(() => calculateStorageAccountId(transferMessage, externalId)).toThrow(
+        /externalId exceeds 64 bytes/,
+      )
+    })
+  })
 })


### PR DESCRIPTION
## WHY ?
Calculate storage account id missing external id arguments 

## HOW ?
Basically copies rust implementation.

We concat external id bytes to serialized transfer message bytes. Updated function throws in case external id exceeds 64 bytes limit. Tests for function  are updated