### PR TITLE
fix(ci): propagate per-package publish failures in ci:publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lefthook": "lefthook install",
     "check-exports": "bun run --filter '*' check-exports",
     "ci:version": "changeset version && bun update",
-    "ci:publish": "bun run build && for dir in packages/*; do (cd \"$dir\" && PKG_NAME=$(jq -r .name package.json) && PKG_VERSION=$(jq -r .version package.json) && if npm view \"$PKG_NAME@$PKG_VERSION\" version 2>/dev/null; then echo \"$PKG_NAME@$PKG_VERSION already published, skipping\"; else bun pm pack && npm publish *.tgz --access public && rm *.tgz; fi); done && changeset tag",
+    "ci:publish": "bun run build && for dir in packages/*; do (cd \"$dir\" && PKG_NAME=$(jq -r .name package.json) && PKG_VERSION=$(jq -r .version package.json) && if npm view \"$PKG_NAME@$PKG_VERSION\" version 2>/dev/null; then echo \"$PKG_NAME@$PKG_VERSION already published, skipping\"; else bun pm pack && npm publish *.tgz --access public && rm *.tgz; fi) || exit 1; done && changeset tag",
     "release": "bun run ci:publish",
     "knip": "knip",
     "example:bitcoin-deposit": "bun run examples/bitcoin-deposit.ts",


### PR DESCRIPTION
## Summary

The `ci:publish` script iterates over `packages/*` and publishes each in a subshell. Previously, per-package failures were silently swallowed because the subshell's exit code was not propagated out of the `for` loop — the step's exit code was determined by `changeset tag` at the very end.

The last release (Version Packages #498) showed this: `@omni-bridge/aptos@0.16.0`, `@omni-bridge/hypercore@0.16.0`, and `@omni-bridge/sdk@0.16.0` all got `404 Not Found - PUT` from npm (OIDC trusted publisher not configured for these new package names), yet the workflow reported success.

## Change

Add `|| exit 1` after the per-package subshell so the first failing publish aborts the loop and the workflow fails visibly.

## Test plan

- [ ] Trigger a release with a misconfigured package and confirm the workflow fails on the failing package rather than silently marching on

🤖 Generated with [Claude Code](https://claude.com/claude-code)