### PR TITLE
Dp502/fix hyper evm

### DIFF
--- a/.changeset/add-missing-hyper-evm-stuff.md
+++ b/.changeset/add-missing-hyper-evm-stuff.md
@@ -1,0 +1,5 @@
+---
+"@omni-bridge/core": fix
+---
+
+Adds missing hyperevm hardcode to utility functions

--- a/.changeset/nzec-bridge-near-to-zec-omft-near.md
+++ b/.changeset/nzec-bridge-near-to-zec-omft-near.md
@@ -1,5 +1,0 @@
----
-"@omni-bridge/core": minor
----
-
-Changes `nzec.bridge.near` to its PoA version `zec.omft.near`.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -96,7 +96,7 @@ const MAINNET_ADDRESSES: ChainAddresses = {
     apiUrl: "https://zcash-mainnet.gateway.tatum.io/",
     rpcUrl: "https://zcash-mainnet.gateway.tatum.io/",
     zcashConnector: "zcash-connector.bridge.near",
-    zcashToken: "zec.omft.near",
+    zcashToken: "nzec.bridge.near",
   },
   strk: { bridge: "0x05f9a4a841dfb7bb3cde33073b2450fe45dcd407fb6c0985a274b0e943ad8598" },
   fogo: {

--- a/packages/core/src/utils/token.ts
+++ b/packages/core/src/utils/token.ts
@@ -11,7 +11,7 @@ import { ChainKind } from "../types.js"
 const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
   // Mainnet
   "nbtc.bridge.near": ChainKind.Btc,
-  "zec.omft.near": ChainKind.Zcash,
+  "nzec.bridge.near": ChainKind.Zcash,
   "eth.bridge.near": ChainKind.Eth,
   "sol.omft.near": ChainKind.Sol,
   "base.omdep.near": ChainKind.Base,

--- a/packages/core/src/utils/token.ts
+++ b/packages/core/src/utils/token.ts
@@ -22,6 +22,7 @@ const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
   "strk-0x65a839eb3847105820d4a2eee84e137f33525e8f.omdep.near": ChainKind.Strk,
   "fogo.omdep.near": ChainKind.Fogo,
   "aptos.omft.near": ChainKind.Aptos,
+  "hlevm.omdep.near": ChainKind.HyperEvm,
   // Testnet
   "nbtc.n-bridge.testnet": ChainKind.Btc,
   "nzcash.n-bridge.testnet": ChainKind.Zcash,
@@ -35,6 +36,7 @@ const KNOWN_BRIDGE_TOKENS: Record<string, ChainKind> = {
   "strk-0x65a839eb3847105820d4a2eee84e137f33525e8f.omnidep.testnet": ChainKind.Strk,
   "fogo.omnidep.testnet": ChainKind.Fogo,
   "aptos-0x16cc6a92839c986682d98bc35f958f4883f9d2a8.omnidep.testnet": ChainKind.Aptos,
+  "hlevm.omnidep.testnet": ChainKind.HyperEvm,
 }
 
 /**
@@ -56,6 +58,7 @@ const CHAIN_PREFIXES: Record<string, ChainKind> = {
   "strk-": ChainKind.Strk,
   "fogo-": ChainKind.Fogo,
   "aptos-": ChainKind.Aptos,
+  "hlevm-": ChainKind.HyperEvm,
 }
 
 /**

--- a/packages/core/tests/token.test.ts
+++ b/packages/core/tests/token.test.ts
@@ -6,7 +6,7 @@ describe("Token Utils", () => {
   describe("isBridgeToken", () => {
     it("should return true for known mainnet bridge tokens", () => {
       expect(isBridgeToken("nbtc.bridge.near")).toBe(true)
-      expect(isBridgeToken("zec.omft.near")).toBe(true)
+      expect(isBridgeToken("nzec.bridge.near")).toBe(true)
       expect(isBridgeToken("eth.bridge.near")).toBe(true)
       expect(isBridgeToken("sol.omft.near")).toBe(true)
       expect(isBridgeToken("base.omdep.near")).toBe(true)
@@ -53,7 +53,7 @@ describe("Token Utils", () => {
       })
 
       it("should parse mainnet Zcash token", () => {
-        expect(parseOriginChain("zec.omft.near")).toBe(ChainKind.Zcash)
+        expect(parseOriginChain("nzec.bridge.near")).toBe(ChainKind.Zcash)
       })
 
       it("should parse mainnet ETH token", () => {

--- a/packages/near/tests/utxo.test.ts
+++ b/packages/near/tests/utxo.test.ts
@@ -376,7 +376,7 @@ describe("NearBuilder UTXO methods", () => {
     })
 
     it("uses mainnet Zcash token address", () => {
-      expect(mainnetBuilder.getUtxoTokenAddress("zcash")).toBe("zec.omft.near")
+      expect(mainnetBuilder.getUtxoTokenAddress("zcash")).toBe("nzec.bridge.near")
     })
   })
 })


### PR DESCRIPTION
# Why
There were missing hyper evm related hardcode in utility functions
Also reverts zec hardcode update as migration has been postponed
